### PR TITLE
Add GitHub actions for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Test
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - name: Install tox and any other packages
+        run: pip install tox
+      - name: Run tox
+        # Run tox using the version of Python in `PATH`
+        run: tox -e py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,12 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      - name: Install tox and any other packages
+      - name: Install tox
         run: pip install tox
-      - name: Run tox
+      - name: Install graphviz binaries for ${{ runner.os }} (${{ runner.arch }})
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install graphviz
+      - name: Run tox (install test dependencies)
         # Run tox using the version of Python in `PATH`
         run: tox -e py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,9 +10,10 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
@@ -23,10 +24,17 @@ jobs:
           cache: pip
       - name: Install tox
         run: pip install tox
-      - name: Install graphviz binaries for ${{ runner.os }} (${{ runner.arch }})
+      - name: Install graphviz binaries for Linux (${{ runner.arch }})
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get -y install graphviz
+      - name: Install graphviz binaries for Windows (${{ runner.arch }})
+        if: runner.os == 'Windows'
+        run: choco install graphviz
+      - name: Install graphviz binaries for macOS (${{ runner.arch }})
+        if: runner.os == 'macOS'
+        run: brew install graphviz
       - name: Run tox (install test dependencies)
         # Run tox using the version of Python in `PATH`
         run: tox -e py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,9 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+    types: [opened, reopened]
 
 permissions:
   contents: read


### PR DESCRIPTION
Hi @idanmoradarthas,

I had some bandwidth to add tests for your repository.

Tests run for py39-py312, and for Linux, Windows, and macOS. The action is triggered at every commit, and when a PR is opened or reopened (~you should see the tests running on this PR, below~ mmh the action is not triggered. It might be because it's not my repository. Here on the fork you can see them in action: https://github.com/lorepirri/DataScienceUtils/pull/1).

The actions used are common ones, nothing custom.

The binaries for `graphviz` are installed using `apt-get` on Linux, `choco` on Windows, and `brew` on macOS. At the moment there is no caching to keep this dependency among the jobs. I did not find an easy solution.

In reference to our previous conversation: https://github.com/idanmoradarthas/DataScienceUtils/pull/36#issuecomment-2346060216