### PR TITLE
Refactor test files for improved modularity.

### DIFF
--- a/tests/metrics_test_utils.py
+++ b/tests/metrics_test_utils.py
@@ -1,0 +1,95 @@
+import numpy as np
+# pandas might be needed if get_dummies or other pd functions are used inside mocks in future.
+# For now, only numpy is strictly necessary for np.zeros, np.unique, np.full.
+# import pandas as pd
+
+class MockClassifier:
+    def __init__(self):
+        self.n_classes_ = 1 # Default for binary or non-multilabel
+        self.y_shape_ = None
+        self.classes_ = [0] # Default classes
+
+    def fit(self, X, y):
+        self.y_shape_ = y.shape
+        if len(y.shape) > 1 and y.shape[1] > 1: # multilabel-indicator
+            self.n_classes_ = y.shape[1]
+            self.classes_ = np.arange(self.n_classes_)
+        elif y.ndim == 1: # binary or multiclass
+            self.classes_ = np.unique(y)
+            self.n_classes_ = len(self.classes_)
+        else: # Single class in multilabel or other edge cases e.g. y.shape = (n,1)
+            self.classes_ = np.unique(y.ravel()) # Flatten to handle (n,1)
+            self.n_classes_ = len(self.classes_)
+            if self.n_classes_ == 0 : # if y was empty or all NaNs resulting in no classes
+                self.n_classes_ = 1
+                self.classes_ = [0] # Fallback for empty y
+
+        return self
+
+    def predict(self, X):
+        # Ensure fit has been called and y_shape_ is not None
+        if self.y_shape_ is None:
+            raise RuntimeError("The classifier has not been fitted yet.")
+
+        if len(self.y_shape_) > 1 and self.y_shape_[1] > 1: # multilabel-indicator
+            preds = np.zeros((len(X), self.n_classes_))
+            if self.n_classes_ > 0:
+                 preds[:, 0] = 1 # Predict the first class for all samples
+            return preds
+        else: # binary or multiclass
+            # Predict the first class encountered during fit, or 0 if no classes were seen
+            # This ensures predict always returns something based on what fit observed.
+            first_class_to_predict = self.classes_[0] if len(self.classes_) > 0 else 0
+            return np.full(len(X), first_class_to_predict)
+
+
+    def score(self, X, y):
+        # Return a dummy score
+        return 0.5
+
+    def get_params(self, deep=True):
+        # scikit-learn's clone function expects this method.
+        return {}
+
+class AnotherMockClassifier:
+    def __init__(self, param=None):
+        self.param = param
+        self.n_classes_ = 1
+        self.y_shape_ = None
+        self.classes_ = [0]
+
+
+    def fit(self, X, y):
+        self.y_shape_ = y.shape
+        if len(y.shape) > 1 and y.shape[1] > 1:
+            self.n_classes_ = y.shape[1]
+            self.classes_ = np.arange(self.n_classes_)
+        elif y.ndim == 1:
+            self.classes_ = np.unique(y)
+            self.n_classes_ = len(self.classes_)
+        else:
+            self.classes_ = np.unique(y.ravel())
+            self.n_classes_ = len(self.classes_)
+            if self.n_classes_ == 0 :
+                self.n_classes_ = 1
+                self.classes_ = [0]
+        return self
+
+    def predict(self, X):
+        if self.y_shape_ is None:
+            raise RuntimeError("The classifier has not been fitted yet.")
+
+        if len(self.y_shape_) > 1 and self.y_shape_[1] > 1:
+            preds = np.zeros((len(X), self.n_classes_))
+            if self.n_classes_ > 0:
+                preds[:, 0] = 1
+            return preds
+        else:
+            first_class_to_predict = self.classes_[0] if len(self.classes_) > 0 else 0
+            return np.full(len(X), first_class_to_predict)
+
+    def score(self, X, y):
+        return 0.6
+
+    def get_params(self, deep=True):
+        return {"param": self.param}

--- a/tests/preprocess_test_utils.py
+++ b/tests/preprocess_test_utils.py
@@ -1,0 +1,88 @@
+import pandas as pd
+import numpy as np
+
+def assert_series_called_with(mock_calls, expected_series, percentile):
+    """Helper function to check if a pandas Series was called with specific values."""
+    for args, _ in mock_calls:
+        series, p = args
+        if (p == percentile and
+                isinstance(series, pd.Series) and
+                series.equals(expected_series)):
+            return True
+    return False
+
+# Mock DataFrames for test_plot_relationship_between_features
+MOCK_DATA_1M_DF = pd.DataFrame({
+    'x1': np.random.rand(10),  # numeric
+    'x4': np.random.rand(10),  # numeric
+    'x5': np.random.rand(10),  # numeric
+    'x7': ['A', 'B', 'A', 'C', 'B', 'A', 'A', 'C', 'B', 'C'],  # categorical
+    'x10': ['X', 'Y', 'X', 'Y', 'X', 'Z', 'Z', 'Y', 'X', 'Z'],  # categorical
+    'x12': [0, 1, 1, 0, 0, 1, 0, 1, 1, 0]  # boolean-like
+})
+
+MOCK_LOAN_DATA_DF = pd.DataFrame({
+    'issue_d': pd.to_datetime(['2023-01-01', '2023-02-01', '2023-01-15', '2023-03-01', '2023-02-10']),
+    'home_ownership': ['RENT', 'MORTGAGE', 'OWN', 'RENT', 'MORTGAGE'],
+    'loan_condition_cat': [0, 1, 1, 0, 1]
+})
+
+MOCK_DAILY_MIN_TEMP_DF = pd.DataFrame({
+    'Date': pd.to_datetime(['2023-01-01', '2023-01-02', '2023-01-03', '2023-01-04', '2023-01-05']),
+    'Temp': [10.0, 12.5, 11.0, 9.5, 13.0]
+})
+
+# Mock DataFrame for test_plot_correlation_dendrogram
+MOCK_DENDROGRAM_DF = pd.DataFrame({
+    'x1': np.random.rand(20), 'x2': np.random.rand(20), 'x3': np.random.rand(20),
+    'x4': np.random.rand(20), 'x5': np.random.rand(20), 'x6': np.random.rand(20),
+    'x7': np.random.choice(['A', 'B', 'C'], 20),
+    'x8': np.random.choice([True, False], 20),
+    'x9': np.random.randn(20),
+    'x10': np.random.choice(['X', 'Y', 'Z'], 20),
+    'x11': np.random.randint(0, 2, 20),
+    'x12': np.random.randint(0, 2, 20)
+})
+
+# Mock DataFrames for test_get_correlated_features
+FEATURE_NAMES_FOR_CORR_TEST = ['income_category_Low', 'income_category_Medium',
+                               'term_ 36 months', 'term_ 60 months',
+                               'interest_payments_High', 'interest_payments_Low',
+                               'loan_condition_cat', 'other_feature_a', 'other_feature_b']
+# Using a fixed seed for reproducibility
+_rng = np.random.default_rng(42)
+_corr_data = _rng.random((len(FEATURE_NAMES_FOR_CORR_TEST), len(FEATURE_NAMES_FOR_CORR_TEST)))
+np.fill_diagonal(_corr_data, 1.0)
+_corr_data = (_corr_data + _corr_data.T) / 2
+np.fill_diagonal(_corr_data, 1.0)
+
+MOCK_CORR_DATA_FOR_GET_FEATURES = pd.DataFrame(_corr_data, index=FEATURE_NAMES_FOR_CORR_TEST, columns=FEATURE_NAMES_FOR_CORR_TEST)
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['income_category_Low', 'income_category_Medium'] = 1.0
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['income_category_Medium', 'income_category_Low'] = 1.0
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['term_ 36 months', 'term_ 60 months'] = 1.0
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['term_ 60 months', 'term_ 36 months'] = 1.0
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['interest_payments_High', 'interest_payments_Low'] = 1.0
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['interest_payments_Low', 'interest_payments_High'] = 1.0
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['income_category_Low', 'loan_condition_cat'] = 0.11821656093586508
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['income_category_Medium', 'loan_condition_cat'] = 0.11821656093586504
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['term_ 36 months', 'loan_condition_cat'] = 0.223606797749979
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['term_ 60 months', 'loan_condition_cat'] = 0.223606797749979
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['interest_payments_High', 'loan_condition_cat'] = 0.13363062095621223
+MOCK_CORR_DATA_FOR_GET_FEATURES.loc['interest_payments_Low', 'loan_condition_cat'] = 0.13363062095621223
+_other_cols_for_corr_test = ['other_feature_a', 'other_feature_b']
+for _col in _other_cols_for_corr_test:
+    MOCK_CORR_DATA_FOR_GET_FEATURES.loc[_col, 'loan_condition_cat'] = _rng.random() * 0.05
+    MOCK_CORR_DATA_FOR_GET_FEATURES.loc['loan_condition_cat', _col] = MOCK_CORR_DATA_FOR_GET_FEATURES.loc[_col, 'loan_condition_cat']
+    for _other_col_inner in _other_cols_for_corr_test:
+        if _col != _other_col_inner:
+             MOCK_CORR_DATA_FOR_GET_FEATURES.loc[_col, _other_col_inner] = _rng.random() * 0.5
+             MOCK_CORR_DATA_FOR_GET_FEATURES.loc[_other_col_inner, _col] = MOCK_CORR_DATA_FOR_GET_FEATURES.loc[_col, _other_col_inner]
+
+COLS_FOR_EMPTY_TEST = ["Clothing ID", "Age", "Title", "Review Text", "Rating", "Recommended IND",
+                       "Positive Feedback Count", "Division Name", "Department Name", "Class Name"]
+_empty_corr_data = _rng.random((len(COLS_FOR_EMPTY_TEST), len(COLS_FOR_EMPTY_TEST)))
+MOCK_EMPTY_CORR_DF = pd.DataFrame(_empty_corr_data, index=COLS_FOR_EMPTY_TEST, columns=COLS_FOR_EMPTY_TEST)
+for _col in MOCK_EMPTY_CORR_DF.columns:
+    if _col != "Class Name":
+         MOCK_EMPTY_CORR_DF[_col] = MOCK_EMPTY_CORR_DF[_col] * 0.1
+    MOCK_EMPTY_CORR_DF.loc[_col,_col] = 1.0


### PR DESCRIPTION
This commit addresses feedback to make `tests/test_metrics.py` and `tests/test_preprocess.py` more modular.

Key changes:

- In `tests/test_metrics.py`:
    - Removed the unused `classifiers` fixture.
    - Moved `MockClassifier` and `AnotherMockClassifier` class definitions to a new shared utility file, `tests/metrics_test_utils.py`.
    - Updated `test_metrics.py` to import these classes from the utility file.

- In `tests/test_preprocess.py`:
    - Created a new shared utility file, `tests/preprocess_test_utils.py`.
    - Moved the helper function `assert_series_called_with` to `preprocess_test_utils.py`.
    - Centralized several mock DataFrame definitions (previously inline or defined within test functions) into `preprocess_test_utils.py`. This includes mock data for:
        - `test_plot_relationship_between_features`
        - `test_get_correlated_features` - `test_get_correlated_features_empty_result` - `test_plot_correlation_dendrogram`
    - Updated `test_preprocess.py` to import and use these shared mock DataFrames and helper functions.
    - Simplified `test_plot_correlation_dendrogram` by removing redundant arguments and directly using imported mock data.

These changes make the test files cleaner, easier to maintain, and promote reusability of test utilities and mock data structures. All tests in the modified files pass.