### PR TITLE
Integrate Ruff, apply linting/formatting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,10 @@ jobs:
         run: |
           python -m hatch env create test
           python -m hatch run test:run
+      - name: Run Ruff Formatter Check
+        run: python -m hatch run test:ruff format --check .
+      - name: Run Ruff Linter
+        run: python -m hatch run test:ruff check .
       - name: Upload coverage to Coveralls
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -504,6 +504,19 @@ If you're new to open source or need any help, don't hesitate to ask questions i
 the [issues](https://github.com/idanmoradarthas/DataScienceUtils/issues) section or reach out to the
 maintainers. We're here to help!
 
+### Code Quality
+
+This project uses [Ruff](https://github.com/astral-sh/ruff) for linting and code formatting.
+Contributors are encouraged to use it to ensure code quality and consistency.
+You can check your code by running:
+
+```bash
+ruff check .
+ruff format .
+```
+
+These checks are also part of our CI pipeline.
+
 ### Why Contribute?
 
 - **Improve your skills**: Gain experience working on a real-world project.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,14 +23,7 @@ copyright = f"{datetime.date.today().year}, Idan Morad"
 author = "Idan Morad"
 
 # The full version, including alpha/beta/rc tags
-release = (
-    Path(__file__)
-    .parents[2]
-    .joinpath("ds_utils", "__init__.py")
-    .read_text()
-    .split("=")[1]
-    .strip()
-)
+release = Path(__file__).parents[2].joinpath("ds_utils", "__init__.py").read_text().split("=")[1].strip()
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,5 +1,5 @@
-# Configuration file for the Sphinx documentation builder.
-#
+"""Configuration file for the Sphinx documentation builder."""
+
 # This file only contains a selection of the most common options. For a full
 # list see the documentation:
 # https://www.sphinx-doc.org/en/master/usage/configuration.html
@@ -13,17 +13,24 @@ from pathlib import Path
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 
-sys.path.insert(0, os.path.abspath('.'))
+sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../../ds_utils"))
 
 # -- Project information -----------------------------------------------------
 
-project = 'Data Science Utils'
-copyright = f'{datetime.date.today().year}, Idan Morad'
-author = 'Idan Morad'
+project = "Data Science Utils"
+copyright = f"{datetime.date.today().year}, Idan Morad"
+author = "Idan Morad"
 
 # The full version, including alpha/beta/rc tags
-release = Path(__file__).parents[2].joinpath("ds_utils", "__init__.py").read_text().split("=")[1].strip()
+release = (
+    Path(__file__)
+    .parents[2]
+    .joinpath("ds_utils", "__init__.py")
+    .read_text()
+    .split("=")[1]
+    .strip()
+)
 
 # -- General configuration ---------------------------------------------------
 
@@ -35,20 +42,20 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
-    "sphinx_copybutton"
+    "sphinx_copybutton",
 ]
 
 # Intersphinx mapping
 intersphinx_mapping = {
-    'python': ('https://docs.python.org/3/', None),
-    'numpy': ('https://numpy.org/doc/stable/', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
-    'sklearn': ('https://scikit-learn.org/stable/', None),
-    'matplotlib': ('https://matplotlib.org/stable/', None),
+    "python": ("https://docs.python.org/3/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    "sklearn": ("https://scikit-learn.org/stable/", None),
+    "matplotlib": ("https://matplotlib.org/stable/", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -60,11 +67,11 @@ exclude_patterns = []
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_rtd_theme'
+html_theme = "sphinx_rtd_theme"
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 # html_static_path = ['_static']
 
-master_doc = 'index'
+master_doc = "index"

--- a/ds_utils/__init__.py
+++ b/ds_utils/__init__.py
@@ -1,1 +1,2 @@
+"""Data Science Utilities package."""
 __version__ = "1.8.1"

--- a/ds_utils/__init__.py
+++ b/ds_utils/__init__.py
@@ -1,2 +1,3 @@
 """Data Science Utilities package."""
+
 __version__ = "1.8.1"

--- a/ds_utils/math_utils.py
+++ b/ds_utils/math_utils.py
@@ -1,4 +1,3 @@
-"""Mathematical utility functions."""
 from typing import Union
 
 import numpy as np
@@ -7,17 +6,18 @@ from numpy.typing import NDArray
 
 
 def safe_percentile(
-        x: Union[pd.Series, NDArray[np.number]], percentile: float
+        x: Union[pd.Series, NDArray[np.number]],
+        percentile: float
 ) -> Union[None, np.floating]:
-    """Calculate the percentile of an array, handling NA values.
+    """
+    Calculate the percentile of an array, handling NA values.
 
     :param x: Input series or numeric numpy array with potentially nullable values.
     :param percentile: Percentile to calculate, must be between 0 and 100.
-    :return: The calculated percentile value, or None if no valid (non-NA) values are
-    present.
+    :return: The calculated percentile value, or None if no valid (non-NA) values are present.
 
     :raise ValueError: If percentile is not between 0 and 100.
-    :raise TypeError: If input is not pandas' Series or numpy array.
+    :raise TypeError: If input is not pandas Series or numpy array.
     """
     if not isinstance(x, (pd.Series, np.ndarray)):
         raise TypeError("Input must be pandas Series or numpy array")

--- a/ds_utils/math_utils.py
+++ b/ds_utils/math_utils.py
@@ -1,3 +1,4 @@
+"""Mathematical utility functions."""
 from typing import Union
 
 import numpy as np
@@ -6,18 +7,17 @@ from numpy.typing import NDArray
 
 
 def safe_percentile(
-        x: Union[pd.Series, NDArray[np.number]],
-        percentile: float
+        x: Union[pd.Series, NDArray[np.number]], percentile: float
 ) -> Union[None, np.floating]:
-    """
-    Calculate the percentile of an array, handling NA values.
+    """Calculate the percentile of an array, handling NA values.
 
     :param x: Input series or numeric numpy array with potentially nullable values.
     :param percentile: Percentile to calculate, must be between 0 and 100.
-    :return: The calculated percentile value, or None if no valid (non-NA) values are present.
+    :return: The calculated percentile value, or None if no valid (non-NA) values are
+    present.
 
     :raise ValueError: If percentile is not between 0 and 100.
-    :raise TypeError: If input is not pandas Series or numpy array.
+    :raise TypeError: If input is not pandas' Series or numpy array.
     """
     if not isinstance(x, (pd.Series, np.ndarray)):
         raise TypeError("Input must be pandas Series or numpy array")

--- a/ds_utils/math_utils.py
+++ b/ds_utils/math_utils.py
@@ -1,3 +1,5 @@
+"""Mathematical utility functions."""
+
 from typing import Union
 
 import numpy as np
@@ -5,19 +7,15 @@ import pandas as pd
 from numpy.typing import NDArray
 
 
-def safe_percentile(
-        x: Union[pd.Series, NDArray[np.number]],
-        percentile: float
-) -> Union[None, np.floating]:
-    """
-    Calculate the percentile of an array, handling NA values.
+def safe_percentile(x: Union[pd.Series, NDArray[np.number]], percentile: float) -> Union[None, np.floating]:
+    """Calculate the percentile of an array, handling NA values.
 
     :param x: Input series or numeric numpy array with potentially nullable values.
-    :param percentile: Percentile to calculate, must be between 0 and 100.
+    :param percentile: Percentile to calculate, it must be between 0 and 100.
     :return: The calculated percentile value, or None if no valid (non-NA) values are present.
 
     :raise ValueError: If percentile is not between 0 and 100.
-    :raise TypeError: If input is not pandas Series or numpy array.
+    :raise TypeError: If input is not pandas' Series or numpy array.
     """
     if not isinstance(x, (pd.Series, np.ndarray)):
         raise TypeError("Input must be pandas Series or numpy array")

--- a/ds_utils/metrics.py
+++ b/ds_utils/metrics.py
@@ -1,5 +1,3 @@
-"""Metrics and visualization tools for evaluating machine learning models."""
-
 import warnings
 from typing import Union, List, Optional, Callable, Dict, Sequence, Tuple
 
@@ -18,7 +16,7 @@ from sklearn.metrics import (
     f1_score,
     roc_curve,
     roc_auc_score,
-    precision_recall_curve,
+    precision_recall_curve
 )
 from sklearn.utils import shuffle
 
@@ -31,53 +29,33 @@ def plot_confusion_matrix(
         annot_kws: Optional[Dict] = None,
         cbar: bool = True,
         cbar_kws: Optional[Dict] = None,
-        **kwargs,
+        **kwargs
 ) -> axes.Axes:
-    """Compute and plot confusion matrix with classification metrics.
-
-    Computes and plots confusion matrix, False Positive Rate, False Negative Rate,
-    Accuracy, and F1 score of a classification.
+    """
+    Computes and plots confusion matrix, False Positive Rate, False Negative Rate, Accuracy, and F1 score of a
+    classification.
 
     :param y_test: array, shape = [n_samples]. Ground truth (correct) target values.
-    :param y_pred: array, shape = [n_samples]. Estimated targets as returned by a
-    classifier.
-    :param labels: List of labels (strings or integers) used to index the matrix,
-    corresponding to n_classes.
-    :param sample_weight: array-like of shape = [n_samples], optional. Optional sample
-    weights for weighting the samples.
-    :param annot_kws: dict of key, value mappings, optional. Keyword arguments for
-    ``ax.text``.
+    :param y_pred: array, shape = [n_samples]. Estimated targets as returned by a classifier.
+    :param labels: List of labels (strings or integers) used to index the matrix, corresponding to n_classes.
+    :param sample_weight: array-like of shape = [n_samples], optional. Optional sample weights for weighting the samples.
+    :param annot_kws: dict of key, value mappings, optional. Keyword arguments for ``ax.text``.
     :param cbar: boolean, optional. Whether to draw a colorbar.
-    :param cbar_kws: dict of key, value mappings, optional. Keyword arguments for
-    ``figure.colorbar``.
-    :param kwargs: other keyword arguments. All other keyword arguments are passed to
-    ``matplotlib.axes.Axes.pcolormesh()``.
+    :param cbar_kws: dict of key, value mappings, optional. Keyword arguments for ``figure.colorbar``.
+    :param kwargs: other keyword arguments. All other keyword arguments are passed to ``matplotlib.axes.Axes.pcolormesh()``.
     :return: Returns the Axes object with the matrix drawn onto it.
     """
     if len(labels) < 2:
         raise ValueError("Number of labels must be greater than 1")
 
-    cnf_matrix = confusion_matrix(
-        y_test, y_pred, labels=labels, sample_weight=sample_weight
-    )
+    cnf_matrix = confusion_matrix(y_test, y_pred, labels=labels, sample_weight=sample_weight)
     if len(labels) == 2:
         df, tnr, tpr = _create_binary_confusion_matrix(cnf_matrix, labels)
     else:
         df, tnr, tpr = _create_multiclass_confusion_matrix(cnf_matrix, labels)
 
-    subplots = _plot_confusion_matrix_helper(
-        df,
-        tnr,
-        tpr,
-        labels,
-        y_pred,
-        y_test,
-        sample_weight,
-        annot_kws,
-        cbar,
-        cbar_kws,
-        kwargs,
-    )
+    subplots = _plot_confusion_matrix_helper(df, tnr, tpr, labels, y_pred, y_test, sample_weight, annot_kws, cbar,
+                                             cbar_kws, kwargs)
     return subplots
 
 
@@ -85,61 +63,42 @@ def _calc_precision_recall(
         fn: Union[float, np.ndarray],
         fp: Union[float, np.ndarray],
         tn: Union[float, np.ndarray],
-        tp: Union[float, np.ndarray],
-) -> Tuple[
-    Union[float, np.ndarray],
-    Union[float, np.ndarray],
-    Union[float, np.ndarray],
-    Union[float, np.ndarray],
-]:
-    tpr = tp / (tp + fn)
-    tnr = tn / (tn + fp)
-    npv = tn / (tn + fn)
-    ppv = tp / (tp + fp)
+        tp: Union[float, np.ndarray]
+) -> Tuple[Union[float, np.ndarray], Union[float, np.ndarray], Union[float, np.ndarray], Union[float, np.ndarray]]:
+    tpr = (tp / (tp + fn))
+    tnr = (tn / (tn + fp))
+    npv = (tn / (tn + fn))
+    ppv = (tp / (tp + fp))
     return npv, ppv, tnr, tpr
 
 
 def _create_multiclass_confusion_matrix(
-        cnf_matrix: np.ndarray, labels: List[Union[str, int]]
+        cnf_matrix: np.ndarray,
+        labels: List[Union[str, int]]
 ) -> Tuple[pd.DataFrame, Union[float, np.ndarray], Union[float, np.ndarray]]:
     fp = (cnf_matrix.sum(axis=0) - np.diag(cnf_matrix)).astype(float)
     fn = (cnf_matrix.sum(axis=1) - np.diag(cnf_matrix)).astype(float)
     tp = (np.diag(cnf_matrix)).astype(float)
     tn = (cnf_matrix.sum() - (fp + fn + tp)).astype(float)
     _, ppv, tnr, tpr = _calc_precision_recall(fn, fp, tn, tp)
-    df = pd.DataFrame(
-        cnf_matrix,
-        columns=[f"{label} - Predicted" for label in labels],
-        index=[f"{label} - Actual" for label in labels],
-    )
+    df = pd.DataFrame(cnf_matrix, columns=[f"{label} - Predicted" for label in labels],
+                      index=[f"{label} - Actual" for label in labels])
     df["Recall"] = tpr
     df = pd.concat(
-        [
-            df,
-            pd.DataFrame(
-                [ppv],
-                columns=[f"{label} - Predicted" for label in labels],
-                index=["Precision"],
-            ),
-        ],
-        sort=False,
-    )
+        [df, pd.DataFrame([ppv], columns=[f"{label} - Predicted" for label in labels], index=["Precision"])],
+        sort=False)
     return df, tnr, tpr
 
 
 def _create_binary_confusion_matrix(
-        cnf_matrix: np.ndarray, labels: List[Union[str, int]]
+        cnf_matrix: np.ndarray,
+        labels: List[Union[str, int]]
 ) -> Tuple[pd.DataFrame, float, float]:
     tn, fp, fn, tp = cnf_matrix.ravel()
     npv, ppv, tnr, tpr = _calc_precision_recall(fn, fp, tn, tp)
-    table = np.array(
-        [[tn, fp, tnr], [fn, tp, tpr], [npv, ppv, np.nan]], dtype=np.float64
-    )
-    df = pd.DataFrame(
-        table,
-        columns=[f"{labels[0]} - Predicted", f"{labels[1]} - Predicted", "Recall"],
-        index=[f"{labels[0]} - Actual", f"{labels[1]} - Actual", "Precision"],
-    )
+    table = np.array([[tn, fp, tnr], [fn, tp, tpr], [npv, ppv, np.nan]], dtype=np.float64)
+    df = pd.DataFrame(table, columns=[f"{labels[0]} - Predicted", f"{labels[1]} - Predicted", "Recall"],
+                      index=[f"{labels[0]} - Actual", f"{labels[1]} - Actual", "Precision"])
     return df, tnr, tpr
 
 
@@ -154,59 +113,27 @@ def _plot_confusion_matrix_helper(
         annot_kws: Optional[Dict],
         cbar: bool,
         cbar_kws: Optional[Dict],
-        kwargs,
+        kwargs
 ) -> axes.Axes:
-    figure, subplots = plt.subplots(
-        nrows=3, ncols=1, gridspec_kw={"height_ratios": [1, 8, 1]}
-    )
+    figure, subplots = plt.subplots(nrows=3, ncols=1, gridspec_kw={'height_ratios': [1, 8, 1]})
     subplots = subplots.flatten()
     subplots[0].set_axis_off()
     if len(labels) == 2:
         subplots[0].text(0, 0.85, f"False Positive Rate: {1 - tnr:.4f}")
         subplots[0].text(0, 0.35, f"False Negative Rate: {1 - tpr:.4f}")
     else:
-        subplots[0].text(
-            0,
-            0.85,
-            f"False Positive Rate: "
-            f"{np.array2string(1 - tnr, precision=2, separator=',')}",
-        )
-        subplots[0].text(
-            0,
-            0.35,
-            f"False Negative Rate: "
-            f"{np.array2string(1 - tpr, precision=2, separator=',')}",
-        )
+        subplots[0].text(0, 0.85, f"False Positive Rate: {np.array2string(1 - tnr, precision=2, separator=',')}")
+        subplots[0].text(0, 0.35, f"False Negative Rate: {np.array2string(1 - tpr, precision=2, separator=',')}")
     subplots[0].text(0, -0.5, "Confusion Matrix:")
-    sns.heatmap(
-        df,
-        annot=True,
-        fmt=".3f",
-        ax=subplots[1],
-        annot_kws=annot_kws,
-        cbar=cbar,
-        cbar_kws=cbar_kws,
-        **kwargs,
-    )
+    sns.heatmap(df, annot=True, fmt=".3f", ax=subplots[1], annot_kws=annot_kws, cbar=cbar, cbar_kws=cbar_kws,
+                **kwargs)
     subplots[2].set_axis_off()
-    subplots[2].text(
-        0,
-        0.15,
-        f"Accuracy: {accuracy_score(y_test, y_pred, sample_weight=sample_weight):.4f}",
-    )
+    subplots[2].text(0, 0.15, f"Accuracy: {accuracy_score(y_test, y_pred, sample_weight=sample_weight):.4f}")
     if len(labels) == 2:
-        f_score = f1_score(
-            y_test,
-            y_pred,
-            labels=labels,
-            pos_label=labels[1],
-            average="binary",
-            sample_weight=sample_weight,
-        )
+        f_score = f1_score(y_test, y_pred, labels=labels, pos_label=labels[1], average="binary",
+                           sample_weight=sample_weight)
     else:
-        f_score = f1_score(
-            y_test, y_pred, labels=labels, average="micro", sample_weight=sample_weight
-        )
+        f_score = f1_score(y_test, y_pred, labels=labels, average="micro", sample_weight=sample_weight)
     subplots[2].text(0, -0.5, f"F1 Score: {f_score:.4f}")
     return subplots
 
@@ -226,37 +153,25 @@ def plot_metric_growth_per_labeled_instances(
         pre_dispatch: Optional[Union[int, str]] = "2*n_jobs",
         *,
         ax: Optional[axes.Axes] = None,
-        **kwargs,
+        **kwargs
 ) -> axes.Axes:
-    """Plot learning curves showing metric performance vs training set size.
+    """
+    Receives train and test sets, and plots the change in the given metric with increasing amounts of trained instances.
 
-    Receives train and test sets, and plots the change in the given metric with
-
-
-    :param X_train: array-like or sparse matrix of shape (n_samples, n_features).
-    The training input samples.
-    :param y_train: array-like of shape (n_samples,). The target values (class labels)
-    as integers or strings.
-    :param X_test: array-like or sparse matrix of shape (n_samples, n_features).
-    The test or evaluation input samples.
+    :param X_train: array-like or sparse matrix of shape (n_samples, n_features). The training input samples.
+    :param y_train: array-like of shape (n_samples,). The target values (class labels) as integers or strings.
+    :param X_test: array-like or sparse matrix of shape (n_samples, n_features). The test or evaluation input samples.
     :param y_test: array-like of shape (n_samples,). The true labels for X_test.
-    :param classifiers_dict: mapping from classifier name to a classifier object.
-    :param n_samples: List of numbers of samples for training batches,
-    optional (default=None).
-    :param quantiles: Percentages' list samples for training batches,
-    optional (default=[0.05, 0.1, ..., 0.95, 1]).
+    :param classifiers_dict: mapping from classifier name to classifier object.
+    :param n_samples: List of numbers of samples for training batches, optional (default=None).
+    :param quantiles: List of percentages of samples for training batches, optional (default=[0.05, 0.1, ..., 0.95, 1]).
                       Used when n_samples=None.
-    :param metric: sklearn.metrics API function which receives y_true and y_pred and
-    returns float.
+    :param metric: sklearn.metrics API function which receives y_true and y_pred and returns float.
     :param random_state: int, RandomState instance or None, optional (default=None).
-                         Controls the shuffling applied to the data before applying the
-                         split.
-    :param n_jobs: int or None, optional (default=None). The number of jobs to run in
-    parallel.
-    :param verbose: int, optional (default=0). Controls the verbosity when fitting and
-    predicting.
-    :param pre_dispatch: int or string, optional. Controls the number of jobs that get
-    dispatched during parallel execution.
+                         Controls the shuffling applied to the data before applying the split.
+    :param n_jobs: int or None, optional (default=None). The number of jobs to run in parallel.
+    :param verbose: int, optional (default=0). Controls the verbosity when fitting and predicting.
+    :param pre_dispatch: int or string, optional. Controls the number of jobs that get dispatched during parallel execution.
     :param ax: matplotlib Axes object, optional. The axes to plot on.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Axes object with the plot drawn onto it.
@@ -264,11 +179,7 @@ def plot_metric_growth_per_labeled_instances(
     if ax is None:
         _, ax = plt.subplots()
 
-    random_state = (
-        RandomState(random_state)
-        if not isinstance(random_state, RandomState)
-        else random_state
-    )
+    random_state = RandomState(random_state) if not isinstance(random_state, RandomState) else random_state
 
     if n_samples is None:
         if quantiles is not None:
@@ -279,28 +190,16 @@ def plot_metric_growth_per_labeled_instances(
     parallel = Parallel(n_jobs=n_jobs, verbose=verbose, pre_dispatch=pre_dispatch)
 
     classifiers_dict_results = dict()
-    samples_list = [
-        shuffle(X_train, y_train, random_state=random_state, n_samples=n_sample)
-        for n_sample in n_samples
-    ]
+    samples_list = [shuffle(X_train, y_train, random_state=random_state, n_samples=n_sample) for n_sample in n_samples]
 
     with parallel:
         for classifier_name, classifier in classifiers_dict.items():
             if verbose > 0:
-                print(
-                    f"Fitting classifier {classifier_name} for {len(n_samples)} times"
-                )
+                print(f"Fitting classifier {classifier_name} for {len(n_samples)} times")
             scores = parallel(
                 delayed(_perform_data_partition_and_evaluation)(
-                    x_train_part,
-                    y_train_part,
-                    X_test,
-                    y_test,
-                    clone(classifier),
-                    metric,
-                )
-                for x_train_part, y_train_part in samples_list
-            )
+                    x_train_part, y_train_part, X_test, y_test, clone(classifier), metric
+                ) for x_train_part, y_train_part in samples_list)
             classifiers_dict_results[classifier_name] = scores
 
     for classifier_name, scores in classifiers_dict_results.items():
@@ -319,7 +218,7 @@ def _perform_data_partition_and_evaluation(
         X_test: np.ndarray,
         y_test: np.ndarray,
         classifier: ClassifierMixin,
-        metric: Callable[[np.ndarray, np.ndarray], float],
+        metric: Callable[[np.ndarray, np.ndarray], float]
 ) -> float:
     if y_train.shape[1] == 1:
         classifier.fit(X_train, y_train.ravel())
@@ -338,75 +237,51 @@ def visualize_accuracy_grouped_by_probability(
         bins: Optional[Union[int, Sequence[float], pd.IntervalIndex]] = None,
         *,
         ax: Optional[axes.Axes] = None,
-        **kwargs,
+        **kwargs
 ) -> axes.Axes:
-    """Plot a stacked bar chart of classifier results by probability bins.
-
-    Receives true test labels and classifier probability predictions, divides and
-    classifies the results, and finally plots a stacked bar chart with the results.
-    `Original code <https://github.com/EthicalML/XAI>`_.
+    """
+    Receives true test labels and classifier probability predictions, divides and classifies the results,
+    and finally plots a stacked bar chart with the results. `Original code <https://github.com/EthicalML/XAI>`_
 
     :param y_test: array, shape = [n_samples]. Ground truth (correct) target values.
     :param labeled_class: the class to inquire about.
-    :param probabilities: array, shape = [n_samples]. Classifier probabilities for the
-    labeled class.
+    :param probabilities: array, shape = [n_samples]. Classifier probabilities for the labeled class.
     :param threshold: the probability threshold for classifying the labeled class.
-    :param display_breakdown: if True, the results will be displayed as "correct" and
-    "incorrect"; otherwise as "true-positives", "true-negatives", "false-positives"
-    and "false-negatives".
+    :param display_breakdown: if True, the results will be displayed as "correct" and "incorrect";
+                              otherwise as "true-positives", "true-negatives", "false-positives" and "false-negatives".
     :param bins: int, sequence of scalars, or IntervalIndex. The criteria to bin by.
     :param ax: matplotlib Axes object, optional. The axes to plot on.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Axes object with the plot drawn onto it.
     """
+
     if bins is None:
         bins = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
 
     if ax is None:
         _, ax = plt.subplots()
 
-    df_results = pd.DataFrame(
-        {
-            "Actual Class": np.vectorize(lambda x: x == labeled_class)(y_test),
-            "Probability": probabilities,
-            "Prediction": probabilities > threshold,
-        }
-    )
+    df_results = pd.DataFrame({
+        "Actual Class": np.vectorize(lambda x: x == labeled_class)(y_test),
+        "Probability": probabilities,
+        "Prediction": probabilities > threshold
+    })
 
-    df_results["True Positive"] = (
-            df_results["Actual Class"] & df_results["Prediction"]
-    ).astype(int)
-    df_results["True Negative"] = (
-            ~df_results["Actual Class"] & ~df_results["Prediction"]
-    ).astype(int)
-    df_results["False Positive"] = (
-            ~df_results["Actual Class"] & df_results["Prediction"]
-    ).astype(int)
-    df_results["False Negative"] = (
-            df_results["Actual Class"] & ~df_results["Prediction"]
-    ).astype(int)
+    df_results["True Positive"] = (df_results["Actual Class"] & df_results["Prediction"]).astype(int)
+    df_results["True Negative"] = (~df_results["Actual Class"] & ~df_results["Prediction"]).astype(int)
+    df_results["False Positive"] = (~df_results["Actual Class"] & df_results["Prediction"]).astype(int)
+    df_results["False Negative"] = (df_results["Actual Class"] & ~df_results["Prediction"]).astype(int)
 
     if display_breakdown:
-        df_results["Correct"] = (
-                df_results["True Positive"] + df_results["True Negative"]
-        )
-        df_results["Incorrect"] = (
-                df_results["False Positive"] + df_results["False Negative"]
-        )
+        df_results["Correct"] = df_results["True Positive"] + df_results["True Negative"]
+        df_results["Incorrect"] = df_results["False Positive"] + df_results["False Negative"]
         display_columns = ["Correct", "Incorrect"]
     else:
-        display_columns = [
-            "True Positive",
-            "True Negative",
-            "False Positive",
-            "False Negative",
-        ]
+        display_columns = ["True Positive", "True Negative", "False Positive", "False Negative"]
 
     # Group the results by probability bins
     df_results["Probability Bin"] = pd.cut(df_results["Probability"], bins=bins)
-    grouped_results = df_results.groupby("Probability Bin", observed=False)[
-        display_columns
-    ].sum()
+    grouped_results = df_results.groupby("Probability Bin", observed=False)[display_columns].sum()
 
     # Plot the results
     grouped_results.plot(kind="bar", stacked=True, ax=ax, **kwargs)
@@ -419,7 +294,7 @@ def visualize_accuracy_grouped_by_probability(
     ax.legend(title="Prediction Type")
 
     # Rotate x-axis labels for better readability
-    plt.setp(ax.get_xticklabels(), rotation=45, ha="right")
+    plt.setp(ax.get_xticklabels(), rotation=45, ha='right')
 
     # Adjust layout to prevent cutting off labels
     plt.tight_layout()
@@ -434,40 +309,31 @@ def plot_roc_curve_with_thresholds_annotations(
         positive_label: Optional[Union[int, float, bool, str]] = None,
         sample_weight: Optional[np.ndarray] = None,
         drop_intermediate: bool = True,
-        average: Optional[str] = "macro",
+        average: Optional[str] = 'macro',
         max_fpr: Optional[float] = None,
-        multi_class: str = "raise",
+        multi_class: str = 'raise',
         labels: Optional[np.ndarray] = None,
         fig: Optional[go.Figure] = None,
-        mode: Optional[str] = "lines+markers",
+        mode: Optional[str] = 'lines+markers',
         add_random_classifier_line: bool = True,
         show_legend: bool = True,
-        **kwargs,
+        **kwargs
 ) -> go.Figure:
-    """Plot ROC curves with threshold annotations for multiple classifiers.
+    """
+    Plot ROC curves with threshold annotations for multiple classifiers.
 
     :param y_true: array-like of shape (n_samples,). True binary labels.
-    :param classifiers_names_and_scores_dict: mapping from classifier name to
-    classifier's score.
-    :param positive_label: int, float, bool or str, default=None. The label of the
-    positive class.
-    :param sample_weight: array-like of shape (n_samples,), default=None.
-    Sample weights.
-    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal
-    thresholds that would not appear on a plotted ROC curve.
-    :param average: {'micro', 'macro', 'samples', 'weighted'} or None, default='macro'.
-    If not None, this determines the type of averaging performed on the data.
-    :param max_fpr: float > 0 and <= 1, default=None. If not None, the standardized
-    partial AUC over the range [0, max_fpr] is returned.
-    :param multi_class: {'raise', 'ovr', 'ovo'}, default='raise'. Determines the type
-    of configuration to use for multiclass targets.
-    :param labels: array-like of shape (n_classes,), default=None. Only used for
-    multiclass targets. List of labels that index the classes in y_score.
+    :param classifiers_names_and_scores_dict: mapping from classifier name to classifier's score.
+    :param positive_label: int, float, bool or str, default=None. The label of the positive class.
+    :param sample_weight: array-like of shape (n_samples,), default=None. Sample weights.
+    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal thresholds which would not appear on a plotted ROC curve.
+    :param average: {'micro', 'macro', 'samples', 'weighted'} or None, default='macro'. If not None, this determines the type of averaging performed on the data.
+    :param max_fpr: float > 0 and <= 1, default=None. If not None, the standardized partial AUC over the range [0, max_fpr] is returned.
+    :param multi_class: {'raise', 'ovr', 'ovo'}, default='raise'. Determines the type of configuration to use for multiclass targets.
+    :param labels: array-like of shape (n_classes,), default=None. Only used for multiclass targets. List of labels that index the classes in y_score.
     :param fig: plotly's Figure object, optional. The figure to plot on.
-    :param mode: str, default='lines+markers'. Determines the drawing mode for this
-    scatter trace.
-    :param add_random_classifier_line: bool, default=True. Whether to plot a diagonal
-    dashed black line which represents a random classifier.
+    :param mode: str, default='lines+markers'. Determines the drawing mode for this scatter trace.
+    :param add_random_classifier_line: bool, default=True. Whether to plot a diagonal dashed black line which represents a random classifier.
     :param show_legend: bool, default=True. Whether to display legend in the plot.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Figure object with the plot drawn onto it.
@@ -479,53 +345,33 @@ def plot_roc_curve_with_thresholds_annotations(
     for classifier_name, y_scores in classifiers_names_and_scores_dict.items():
         if y_true.shape != y_scores.shape:
             raise ValueError(
-                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} "
-                f"for classifier {classifier_name}"
-            )
+                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} for classifier {classifier_name}")
 
         try:
-            fpr_array, tpr_array, thresholds = roc_curve(
-                y_true,
-                y_scores,
-                pos_label=positive_label,
-                sample_weight=sample_weight,
-                drop_intermediate=drop_intermediate,
-            )
+            fpr_array, tpr_array, thresholds = roc_curve(y_true, y_scores, pos_label=positive_label,
+                                                         sample_weight=sample_weight,
+                                                         drop_intermediate=drop_intermediate)
         except ValueError as e:
-            raise ValueError(
-                f"Error calculating ROC curve for classifier {classifier_name}: "
-                f"{str(e)}"
-            )
+            raise ValueError(f"Error calculating ROC curve for classifier {classifier_name}: {str(e)}")
 
         try:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UndefinedMetricWarning)
-                auc_score = roc_auc_score(
-                    y_true,
-                    y_scores,
-                    average=average,
-                    sample_weight=sample_weight,
-                    max_fpr=max_fpr,
-                    multi_class=multi_class,
-                    labels=labels,
-                )
+                auc_score = roc_auc_score(y_true, y_scores, average=average, sample_weight=sample_weight,
+                                          max_fpr=max_fpr,
+                                          multi_class=multi_class, labels=labels)
         except ValueError as e:
-            raise ValueError(
-                f"Error calculating AUC score for classifier {classifier_name}: "
-                f"{str(e)}"
-            )
+            raise ValueError(f"Error calculating AUC score for classifier {classifier_name}: {str(e)}")
 
         fig.add_trace(
             go.Scatter(
                 x=fpr_array,
                 y=tpr_array,
                 mode=mode,
-                text=[
-                    f"Prob: {threshold:.2f}<br>FPR: {fpr:.2f}<br>TPR: {tpr:.2f}"
-                    for fpr, tpr, threshold in zip(fpr_array, tpr_array, thresholds)
-                ],
+                text=[f'Prob: {threshold:.2f}<br>FPR: {fpr:.2f}<br>TPR: {tpr:.2f}' for fpr, tpr, threshold in
+                      zip(fpr_array, tpr_array, thresholds)],
                 name=f"{classifier_name} (AUC = {auc_score:.2f})",
-                **kwargs,
+                **kwargs
             )
         )
 
@@ -534,16 +380,16 @@ def plot_roc_curve_with_thresholds_annotations(
             go.Scatter(
                 x=[0, 1],
                 y=[0, 1],
-                mode="lines",
-                line=dict(dash="dash", color="black"),
-                name="Random Classifier",
+                mode='lines',
+                line=dict(dash='dash', color='black'),
+                name="Random Classifier"
             )
         )
 
     fig.update_layout(
         xaxis_title="False Positive Rate",
         yaxis_title="True Positive Rate",
-        showlegend=show_legend,
+        showlegend=show_legend
     )
 
     return fig
@@ -557,27 +403,22 @@ def plot_precision_recall_curve_with_thresholds_annotations(
         sample_weight: Optional[np.ndarray] = None,
         drop_intermediate: bool = True,
         fig: Optional[go.Figure] = None,
-        mode: Optional[str] = "lines+markers",
+        mode: Optional[str] = 'lines+markers',
         add_random_classifier_line: bool = False,
         show_legend: bool = True,
-        **kwargs,
+        **kwargs
 ) -> go.Figure:
-    """Plot Precision-Recall curves with threshold annotations for multiple classifiers.
+    """
+    Plot Precision-Recall curves with threshold annotations for multiple classifiers.
 
     :param y_true: array-like of shape (n_samples,). True binary labels.
-    :param classifiers_names_and_scores_dict: mapping from classifier name to
-    classifier's score.
-    :param positive_label: int, float, bool or str, default=None. The label of the
-    positive class.
-    :param sample_weight: array-like of shape (n_samples,), default=None.
-    Sample weights.
-    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal
-    thresholds that would not appear on a plotted Precision-Recall curve.
+    :param classifiers_names_and_scores_dict: mapping from classifier name to classifier's score.
+    :param positive_label: int, float, bool or str, default=None. The label of the positive class.
+    :param sample_weight: array-like of shape (n_samples,), default=None. Sample weights.
+    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal thresholds which would not appear on a plotted Precision-Recall curve.
     :param fig: plotly's Figure object, optional. The figure to plot on.
-    :param mode: str, default='lines+markers'. Determines the drawing mode for this
-    scatter trace.
-    :param add_random_classifier_line: bool, default=False. Whether to plot a diagonal
-    dashed black line which represents a random classifier.
+    :param mode: str, default='lines+markers'. Determines the drawing mode for this scatter trace.
+    :param add_random_classifier_line: bool, default=False. Whether to plot a diagonal dashed black line which represents a random classifier.
     :param show_legend: bool, default=True. Whether to display legend in the plot.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Figure object with the plot drawn onto it.
@@ -589,37 +430,24 @@ def plot_precision_recall_curve_with_thresholds_annotations(
     for classifier_name, y_scores in classifiers_names_and_scores_dict.items():
         if y_true.shape != y_scores.shape:
             raise ValueError(
-                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} "
-                f"for classifier {classifier_name}"
-            )
+                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} for classifier {classifier_name}")
         try:
-            precision_array, recall_array, thresholds = precision_recall_curve(
-                y_true,
-                y_scores,
-                pos_label=positive_label,
-                sample_weight=sample_weight,
-                drop_intermediate=drop_intermediate,
-            )
+            precision_array, recall_array, thresholds = precision_recall_curve(y_true, y_scores,
+                                                                               pos_label=positive_label,
+                                                                               sample_weight=sample_weight,
+                                                                               drop_intermediate=drop_intermediate)
         except ValueError as e:
-            raise ValueError(
-                f"Error calculating Precision-Recall curve for classifier "
-                f"{classifier_name}: {str(e)}"
-            )
+            raise ValueError(f"Error calculating Precision-Recall curve for classifier {classifier_name}: {str(e)}")
 
         fig.add_trace(
             go.Scatter(
                 x=recall_array,
                 y=precision_array,
                 mode=mode,
-                text=[
-                    f"Prob: {threshold:.2f}<br>Precision: {precision:.2f}<br>"
-                    f"Recall: {recall:.2f}"
-                    for precision, recall, threshold in zip(
-                        precision_array, recall_array, thresholds
-                    )
-                ],
+                text=[f'Prob: {threshold:.2f}<br>Precision: {precision:.2f}<br>Recall: {recall:.2f}' for
+                      precision, recall, threshold in zip(precision_array, recall_array, thresholds)],
                 name=classifier_name,
-                **kwargs,
+                **kwargs
             )
         )
 
@@ -628,14 +456,16 @@ def plot_precision_recall_curve_with_thresholds_annotations(
             go.Scatter(
                 x=[1, 0],
                 y=[0, 1],
-                mode="lines",
-                line=dict(dash="dash", color="black"),
-                name="Random Classifier",
+                mode='lines',
+                line=dict(dash='dash', color='black'),
+                name="Random Classifier"
             )
         )
 
     fig.update_layout(
-        xaxis_title="Recall", yaxis_title="Precision", showlegend=show_legend
+        xaxis_title="Recall",
+        yaxis_title="Precision",
+        showlegend=show_legend
     )
 
     return fig

--- a/ds_utils/metrics.py
+++ b/ds_utils/metrics.py
@@ -1,3 +1,5 @@
+"""Metrics and visualization tools for evaluating machine learning models."""
+
 import warnings
 from typing import Union, List, Optional, Callable, Dict, Sequence, Tuple
 
@@ -10,14 +12,7 @@ from matplotlib import pyplot as plt, axes
 from numpy.random.mtrand import RandomState
 from sklearn.base import ClassifierMixin, clone
 from sklearn.exceptions import UndefinedMetricWarning
-from sklearn.metrics import (
-    confusion_matrix,
-    accuracy_score,
-    f1_score,
-    roc_curve,
-    roc_auc_score,
-    precision_recall_curve
-)
+from sklearn.metrics import confusion_matrix, accuracy_score, f1_score, roc_curve, roc_auc_score, precision_recall_curve
 from sklearn.utils import shuffle
 
 
@@ -29,20 +24,23 @@ def plot_confusion_matrix(
         annot_kws: Optional[Dict] = None,
         cbar: bool = True,
         cbar_kws: Optional[Dict] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
-    """
+    """Compute and plot confusion matrix with classification metrics.
+
     Computes and plots confusion matrix, False Positive Rate, False Negative Rate, Accuracy, and F1 score of a
     classification.
 
     :param y_test: array, shape = [n_samples]. Ground truth (correct) target values.
     :param y_pred: array, shape = [n_samples]. Estimated targets as returned by a classifier.
     :param labels: List of labels (strings or integers) used to index the matrix, corresponding to n_classes.
-    :param sample_weight: array-like of shape = [n_samples], optional. Optional sample weights for weighting the samples.
+    :param sample_weight: array-like of shape = [n_samples], optional. Optional sample weights for weighting the
+                          samples.
     :param annot_kws: dict of key, value mappings, optional. Keyword arguments for ``ax.text``.
     :param cbar: boolean, optional. Whether to draw a colorbar.
     :param cbar_kws: dict of key, value mappings, optional. Keyword arguments for ``figure.colorbar``.
-    :param kwargs: other keyword arguments. All other keyword arguments are passed to ``matplotlib.axes.Axes.pcolormesh()``.
+    :param kwargs: other keyword arguments. All other keyword arguments are passed
+                   to ``matplotlib.axes.Axes.pcolormesh()``.
     :return: Returns the Axes object with the matrix drawn onto it.
     """
     if len(labels) < 2:
@@ -54,8 +52,9 @@ def plot_confusion_matrix(
     else:
         df, tnr, tpr = _create_multiclass_confusion_matrix(cnf_matrix, labels)
 
-    subplots = _plot_confusion_matrix_helper(df, tnr, tpr, labels, y_pred, y_test, sample_weight, annot_kws, cbar,
-                                             cbar_kws, kwargs)
+    subplots = _plot_confusion_matrix_helper(
+        df, tnr, tpr, labels, y_pred, y_test, sample_weight, annot_kws, cbar, cbar_kws, kwargs
+    )
     return subplots
 
 
@@ -63,42 +62,46 @@ def _calc_precision_recall(
         fn: Union[float, np.ndarray],
         fp: Union[float, np.ndarray],
         tn: Union[float, np.ndarray],
-        tp: Union[float, np.ndarray]
+        tp: Union[float, np.ndarray],
 ) -> Tuple[Union[float, np.ndarray], Union[float, np.ndarray], Union[float, np.ndarray], Union[float, np.ndarray]]:
-    tpr = (tp / (tp + fn))
-    tnr = (tn / (tn + fp))
-    npv = (tn / (tn + fn))
-    ppv = (tp / (tp + fp))
+    tpr = tp / (tp + fn)
+    tnr = tn / (tn + fp)
+    npv = tn / (tn + fn)
+    ppv = tp / (tp + fp)
     return npv, ppv, tnr, tpr
 
 
 def _create_multiclass_confusion_matrix(
-        cnf_matrix: np.ndarray,
-        labels: List[Union[str, int]]
+        cnf_matrix: np.ndarray, labels: List[Union[str, int]]
 ) -> Tuple[pd.DataFrame, Union[float, np.ndarray], Union[float, np.ndarray]]:
     fp = (cnf_matrix.sum(axis=0) - np.diag(cnf_matrix)).astype(float)
     fn = (cnf_matrix.sum(axis=1) - np.diag(cnf_matrix)).astype(float)
     tp = (np.diag(cnf_matrix)).astype(float)
     tn = (cnf_matrix.sum() - (fp + fn + tp)).astype(float)
     _, ppv, tnr, tpr = _calc_precision_recall(fn, fp, tn, tp)
-    df = pd.DataFrame(cnf_matrix, columns=[f"{label} - Predicted" for label in labels],
-                      index=[f"{label} - Actual" for label in labels])
+    df = pd.DataFrame(
+        cnf_matrix,
+        columns=[f"{label} - Predicted" for label in labels],
+        index=[f"{label} - Actual" for label in labels],
+    )
     df["Recall"] = tpr
     df = pd.concat(
-        [df, pd.DataFrame([ppv], columns=[f"{label} - Predicted" for label in labels], index=["Precision"])],
-        sort=False)
+        [df, pd.DataFrame([ppv], columns=[f"{label} - Predicted" for label in labels], index=["Precision"])], sort=False
+    )
     return df, tnr, tpr
 
 
 def _create_binary_confusion_matrix(
-        cnf_matrix: np.ndarray,
-        labels: List[Union[str, int]]
+        cnf_matrix: np.ndarray, labels: List[Union[str, int]]
 ) -> Tuple[pd.DataFrame, float, float]:
     tn, fp, fn, tp = cnf_matrix.ravel()
     npv, ppv, tnr, tpr = _calc_precision_recall(fn, fp, tn, tp)
     table = np.array([[tn, fp, tnr], [fn, tp, tpr], [npv, ppv, np.nan]], dtype=np.float64)
-    df = pd.DataFrame(table, columns=[f"{labels[0]} - Predicted", f"{labels[1]} - Predicted", "Recall"],
-                      index=[f"{labels[0]} - Actual", f"{labels[1]} - Actual", "Precision"])
+    df = pd.DataFrame(
+        table,
+        columns=[f"{labels[0]} - Predicted", f"{labels[1]} - Predicted", "Recall"],
+        index=[f"{labels[0]} - Actual", f"{labels[1]} - Actual", "Precision"],
+    )
     return df, tnr, tpr
 
 
@@ -113,9 +116,9 @@ def _plot_confusion_matrix_helper(
         annot_kws: Optional[Dict],
         cbar: bool,
         cbar_kws: Optional[Dict],
-        kwargs
+        kwargs,
 ) -> axes.Axes:
-    figure, subplots = plt.subplots(nrows=3, ncols=1, gridspec_kw={'height_ratios': [1, 8, 1]})
+    figure, subplots = plt.subplots(nrows=3, ncols=1, gridspec_kw={"height_ratios": [1, 8, 1]})
     subplots = subplots.flatten()
     subplots[0].set_axis_off()
     if len(labels) == 2:
@@ -125,13 +128,13 @@ def _plot_confusion_matrix_helper(
         subplots[0].text(0, 0.85, f"False Positive Rate: {np.array2string(1 - tnr, precision=2, separator=',')}")
         subplots[0].text(0, 0.35, f"False Negative Rate: {np.array2string(1 - tpr, precision=2, separator=',')}")
     subplots[0].text(0, -0.5, "Confusion Matrix:")
-    sns.heatmap(df, annot=True, fmt=".3f", ax=subplots[1], annot_kws=annot_kws, cbar=cbar, cbar_kws=cbar_kws,
-                **kwargs)
+    sns.heatmap(df, annot=True, fmt=".3f", ax=subplots[1], annot_kws=annot_kws, cbar=cbar, cbar_kws=cbar_kws, **kwargs)
     subplots[2].set_axis_off()
     subplots[2].text(0, 0.15, f"Accuracy: {accuracy_score(y_test, y_pred, sample_weight=sample_weight):.4f}")
     if len(labels) == 2:
-        f_score = f1_score(y_test, y_pred, labels=labels, pos_label=labels[1], average="binary",
-                           sample_weight=sample_weight)
+        f_score = f1_score(
+            y_test, y_pred, labels=labels, pos_label=labels[1], average="binary", sample_weight=sample_weight
+        )
     else:
         f_score = f1_score(y_test, y_pred, labels=labels, average="micro", sample_weight=sample_weight)
     subplots[2].text(0, -0.5, f"F1 Score: {f_score:.4f}")
@@ -153,25 +156,28 @@ def plot_metric_growth_per_labeled_instances(
         pre_dispatch: Optional[Union[int, str]] = "2*n_jobs",
         *,
         ax: Optional[axes.Axes] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
-    """
-    Receives train and test sets, and plots the change in the given metric with increasing amounts of trained instances.
+    """Plot learning curves showing metric performance vs training set size.
+
+    Receives train and test sets, and plots the change in the given metric with increasing numbers of trained
+    instances.
 
     :param X_train: array-like or sparse matrix of shape (n_samples, n_features). The training input samples.
     :param y_train: array-like of shape (n_samples,). The target values (class labels) as integers or strings.
     :param X_test: array-like or sparse matrix of shape (n_samples, n_features). The test or evaluation input samples.
     :param y_test: array-like of shape (n_samples,). The true labels for X_test.
-    :param classifiers_dict: mapping from classifier name to classifier object.
+    :param classifiers_dict: mapping from classifier name to a classifier object.
     :param n_samples: List of numbers of samples for training batches, optional (default=None).
-    :param quantiles: List of percentages of samples for training batches, optional (default=[0.05, 0.1, ..., 0.95, 1]).
+    :param quantiles: List of sample percentages for training batches, optional (default=[0.05, 0.1, ..., 0.95, 1]).
                       Used when n_samples=None.
     :param metric: sklearn.metrics API function which receives y_true and y_pred and returns float.
     :param random_state: int, RandomState instance or None, optional (default=None).
                          Controls the shuffling applied to the data before applying the split.
     :param n_jobs: int or None, optional (default=None). The number of jobs to run in parallel.
     :param verbose: int, optional (default=0). Controls the verbosity when fitting and predicting.
-    :param pre_dispatch: int or string, optional. Controls the number of jobs that get dispatched during parallel execution.
+    :param pre_dispatch: int or string, optional. Controls the number of jobs that get dispatched during parallel
+                         execution.
     :param ax: matplotlib Axes object, optional. The axes to plot on.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Axes object with the plot drawn onto it.
@@ -199,7 +205,9 @@ def plot_metric_growth_per_labeled_instances(
             scores = parallel(
                 delayed(_perform_data_partition_and_evaluation)(
                     x_train_part, y_train_part, X_test, y_test, clone(classifier), metric
-                ) for x_train_part, y_train_part in samples_list)
+                )
+                for x_train_part, y_train_part in samples_list
+            )
             classifiers_dict_results[classifier_name] = scores
 
     for classifier_name, scores in classifiers_dict_results.items():
@@ -218,7 +226,7 @@ def _perform_data_partition_and_evaluation(
         X_test: np.ndarray,
         y_test: np.ndarray,
         classifier: ClassifierMixin,
-        metric: Callable[[np.ndarray, np.ndarray], float]
+        metric: Callable[[np.ndarray, np.ndarray], float],
 ) -> float:
     if y_train.shape[1] == 1:
         classifier.fit(X_train, y_train.ravel())
@@ -237,11 +245,13 @@ def visualize_accuracy_grouped_by_probability(
         bins: Optional[Union[int, Sequence[float], pd.IntervalIndex]] = None,
         *,
         ax: Optional[axes.Axes] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
-    """
+    """Plot a stacked bar chart of classifier results by probability bins.
+
     Receives true test labels and classifier probability predictions, divides and classifies the results,
-    and finally plots a stacked bar chart with the results. `Original code <https://github.com/EthicalML/XAI>`_
+    and finally plots a stacked bar chart with the results.
+    `Original code <https://github.com/EthicalML/XAI>`_.
 
     :param y_test: array, shape = [n_samples]. Ground truth (correct) target values.
     :param labeled_class: the class to inquire about.
@@ -254,18 +264,19 @@ def visualize_accuracy_grouped_by_probability(
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Axes object with the plot drawn onto it.
     """
-
     if bins is None:
         bins = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
 
     if ax is None:
         _, ax = plt.subplots()
 
-    df_results = pd.DataFrame({
-        "Actual Class": np.vectorize(lambda x: x == labeled_class)(y_test),
-        "Probability": probabilities,
-        "Prediction": probabilities > threshold
-    })
+    df_results = pd.DataFrame(
+        {
+            "Actual Class": np.vectorize(lambda x: x == labeled_class)(y_test),
+            "Probability": probabilities,
+            "Prediction": probabilities > threshold,
+        }
+    )
 
     df_results["True Positive"] = (df_results["Actual Class"] & df_results["Prediction"]).astype(int)
     df_results["True Negative"] = (~df_results["Actual Class"] & ~df_results["Prediction"]).astype(int)
@@ -294,7 +305,7 @@ def visualize_accuracy_grouped_by_probability(
     ax.legend(title="Prediction Type")
 
     # Rotate x-axis labels for better readability
-    plt.setp(ax.get_xticklabels(), rotation=45, ha='right')
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="right")
 
     # Adjust layout to prevent cutting off labels
     plt.tight_layout()
@@ -309,31 +320,36 @@ def plot_roc_curve_with_thresholds_annotations(
         positive_label: Optional[Union[int, float, bool, str]] = None,
         sample_weight: Optional[np.ndarray] = None,
         drop_intermediate: bool = True,
-        average: Optional[str] = 'macro',
+        average: Optional[str] = "macro",
         max_fpr: Optional[float] = None,
-        multi_class: str = 'raise',
+        multi_class: str = "raise",
         labels: Optional[np.ndarray] = None,
         fig: Optional[go.Figure] = None,
-        mode: Optional[str] = 'lines+markers',
+        mode: Optional[str] = "lines+markers",
         add_random_classifier_line: bool = True,
         show_legend: bool = True,
-        **kwargs
+        **kwargs,
 ) -> go.Figure:
-    """
-    Plot ROC curves with threshold annotations for multiple classifiers.
+    """Plot ROC curves with threshold annotations for multiple classifiers.
 
     :param y_true: array-like of shape (n_samples,). True binary labels.
     :param classifiers_names_and_scores_dict: mapping from classifier name to classifier's score.
     :param positive_label: int, float, bool or str, default=None. The label of the positive class.
     :param sample_weight: array-like of shape (n_samples,), default=None. Sample weights.
-    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal thresholds which would not appear on a plotted ROC curve.
-    :param average: {'micro', 'macro', 'samples', 'weighted'} or None, default='macro'. If not None, this determines the type of averaging performed on the data.
-    :param max_fpr: float > 0 and <= 1, default=None. If not None, the standardized partial AUC over the range [0, max_fpr] is returned.
-    :param multi_class: {'raise', 'ovr', 'ovo'}, default='raise'. Determines the type of configuration to use for multiclass targets.
-    :param labels: array-like of shape (n_classes,), default=None. Only used for multiclass targets. List of labels that index the classes in y_score.
+    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal thresholds that would not appear on
+                              a plotted ROC curve.
+    :param average: {'micro', 'macro', 'samples', 'weighted'} or None, default='macro'. If not None, this determines
+                    the type of averaging performed on the data.
+    :param max_fpr: float > 0 and <= 1, default=None. If not None, the standardized partial AUC over the range
+                    [0, max_fpr] is returned.
+    :param multi_class: {'raise', 'ovr', 'ovo'}, default='raise'. Determines the type of configuration to use for
+                        multiclass targets.
+    :param labels: array-like of shape (n_classes,), default=None. Only used for multiclass targets. List of labels
+                   that index the classes in y_score.
     :param fig: plotly's Figure object, optional. The figure to plot on.
     :param mode: str, default='lines+markers'. Determines the drawing mode for this scatter trace.
-    :param add_random_classifier_line: bool, default=True. Whether to plot a diagonal dashed black line which represents a random classifier.
+    :param add_random_classifier_line: bool, default=True. Whether to plot a diagonal dashed black line which
+                                       represents a random classifier.
     :param show_legend: bool, default=True. Whether to display legend in the plot.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Figure object with the plot drawn onto it.
@@ -345,21 +361,32 @@ def plot_roc_curve_with_thresholds_annotations(
     for classifier_name, y_scores in classifiers_names_and_scores_dict.items():
         if y_true.shape != y_scores.shape:
             raise ValueError(
-                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} for classifier {classifier_name}")
+                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} for classifier {classifier_name}"
+            )
 
         try:
-            fpr_array, tpr_array, thresholds = roc_curve(y_true, y_scores, pos_label=positive_label,
-                                                         sample_weight=sample_weight,
-                                                         drop_intermediate=drop_intermediate)
+            fpr_array, tpr_array, thresholds = roc_curve(
+                y_true,
+                y_scores,
+                pos_label=positive_label,
+                sample_weight=sample_weight,
+                drop_intermediate=drop_intermediate,
+            )
         except ValueError as e:
             raise ValueError(f"Error calculating ROC curve for classifier {classifier_name}: {str(e)}")
 
         try:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UndefinedMetricWarning)
-                auc_score = roc_auc_score(y_true, y_scores, average=average, sample_weight=sample_weight,
-                                          max_fpr=max_fpr,
-                                          multi_class=multi_class, labels=labels)
+                auc_score = roc_auc_score(
+                    y_true,
+                    y_scores,
+                    average=average,
+                    sample_weight=sample_weight,
+                    max_fpr=max_fpr,
+                    multi_class=multi_class,
+                    labels=labels,
+                )
         except ValueError as e:
             raise ValueError(f"Error calculating AUC score for classifier {classifier_name}: {str(e)}")
 
@@ -368,29 +395,23 @@ def plot_roc_curve_with_thresholds_annotations(
                 x=fpr_array,
                 y=tpr_array,
                 mode=mode,
-                text=[f'Prob: {threshold:.2f}<br>FPR: {fpr:.2f}<br>TPR: {tpr:.2f}' for fpr, tpr, threshold in
-                      zip(fpr_array, tpr_array, thresholds)],
+                text=[
+                    f"Prob: {threshold:.2f}<br>FPR: {fpr:.2f}<br>TPR: {tpr:.2f}"
+                    for fpr, tpr, threshold in zip(fpr_array, tpr_array, thresholds)
+                ],
                 name=f"{classifier_name} (AUC = {auc_score:.2f})",
-                **kwargs
+                **kwargs,
             )
         )
 
     if add_random_classifier_line:  # Add dashed line for random classifier
         fig.add_trace(
             go.Scatter(
-                x=[0, 1],
-                y=[0, 1],
-                mode='lines',
-                line=dict(dash='dash', color='black'),
-                name="Random Classifier"
+                x=[0, 1], y=[0, 1], mode="lines", line=dict(dash="dash", color="black"), name="Random Classifier"
             )
         )
 
-    fig.update_layout(
-        xaxis_title="False Positive Rate",
-        yaxis_title="True Positive Rate",
-        showlegend=show_legend
-    )
+    fig.update_layout(xaxis_title="False Positive Rate", yaxis_title="True Positive Rate", showlegend=show_legend)
 
     return fig
 
@@ -403,22 +424,23 @@ def plot_precision_recall_curve_with_thresholds_annotations(
         sample_weight: Optional[np.ndarray] = None,
         drop_intermediate: bool = True,
         fig: Optional[go.Figure] = None,
-        mode: Optional[str] = 'lines+markers',
+        mode: Optional[str] = "lines+markers",
         add_random_classifier_line: bool = False,
         show_legend: bool = True,
-        **kwargs
+        **kwargs,
 ) -> go.Figure:
-    """
-    Plot Precision-Recall curves with threshold annotations for multiple classifiers.
+    """Plot Precision-Recall curves with threshold annotations for multiple classifiers.
 
     :param y_true: array-like of shape (n_samples,). True binary labels.
     :param classifiers_names_and_scores_dict: mapping from classifier name to classifier's score.
     :param positive_label: int, float, bool or str, default=None. The label of the positive class.
     :param sample_weight: array-like of shape (n_samples,), default=None. Sample weights.
-    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal thresholds which would not appear on a plotted Precision-Recall curve.
+    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal thresholds that would not appear on
+                              a plotted Precision-Recall curve.
     :param fig: plotly's Figure object, optional. The figure to plot on.
     :param mode: str, default='lines+markers'. Determines the drawing mode for this scatter trace.
-    :param add_random_classifier_line: bool, default=False. Whether to plot a diagonal dashed black line which represents a random classifier.
+    :param add_random_classifier_line: bool, default=False. Whether to plot a diagonal dashed black line which
+                                       represents a random classifier.
     :param show_legend: bool, default=True. Whether to display legend in the plot.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Figure object with the plot drawn onto it.
@@ -430,12 +452,16 @@ def plot_precision_recall_curve_with_thresholds_annotations(
     for classifier_name, y_scores in classifiers_names_and_scores_dict.items():
         if y_true.shape != y_scores.shape:
             raise ValueError(
-                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} for classifier {classifier_name}")
+                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} for classifier {classifier_name}"
+            )
         try:
-            precision_array, recall_array, thresholds = precision_recall_curve(y_true, y_scores,
-                                                                               pos_label=positive_label,
-                                                                               sample_weight=sample_weight,
-                                                                               drop_intermediate=drop_intermediate)
+            precision_array, recall_array, thresholds = precision_recall_curve(
+                y_true,
+                y_scores,
+                pos_label=positive_label,
+                sample_weight=sample_weight,
+                drop_intermediate=drop_intermediate,
+            )
         except ValueError as e:
             raise ValueError(f"Error calculating Precision-Recall curve for classifier {classifier_name}: {str(e)}")
 
@@ -444,28 +470,22 @@ def plot_precision_recall_curve_with_thresholds_annotations(
                 x=recall_array,
                 y=precision_array,
                 mode=mode,
-                text=[f'Prob: {threshold:.2f}<br>Precision: {precision:.2f}<br>Recall: {recall:.2f}' for
-                      precision, recall, threshold in zip(precision_array, recall_array, thresholds)],
+                text=[
+                    f"Prob: {threshold:.2f}<br>Precision: {precision:.2f}<br>Recall: {recall:.2f}"
+                    for precision, recall, threshold in zip(precision_array, recall_array, thresholds)
+                ],
                 name=classifier_name,
-                **kwargs
+                **kwargs,
             )
         )
 
     if add_random_classifier_line:  # Add dashed line for random classifier
         fig.add_trace(
             go.Scatter(
-                x=[1, 0],
-                y=[0, 1],
-                mode='lines',
-                line=dict(dash='dash', color='black'),
-                name="Random Classifier"
+                x=[1, 0], y=[0, 1], mode="lines", line=dict(dash="dash", color="black"), name="Random Classifier"
             )
         )
 
-    fig.update_layout(
-        xaxis_title="Recall",
-        yaxis_title="Precision",
-        showlegend=show_legend
-    )
+    fig.update_layout(xaxis_title="Recall", yaxis_title="Precision", showlegend=show_legend)
 
     return fig

--- a/ds_utils/metrics.py
+++ b/ds_utils/metrics.py
@@ -1,3 +1,5 @@
+"""Metrics and visualization tools for evaluating machine learning models."""
+
 import warnings
 from typing import Union, List, Optional, Callable, Dict, Sequence, Tuple
 
@@ -16,7 +18,7 @@ from sklearn.metrics import (
     f1_score,
     roc_curve,
     roc_auc_score,
-    precision_recall_curve
+    precision_recall_curve,
 )
 from sklearn.utils import shuffle
 
@@ -29,33 +31,53 @@ def plot_confusion_matrix(
         annot_kws: Optional[Dict] = None,
         cbar: bool = True,
         cbar_kws: Optional[Dict] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
-    """
-    Computes and plots confusion matrix, False Positive Rate, False Negative Rate, Accuracy, and F1 score of a
-    classification.
+    """Compute and plot confusion matrix with classification metrics.
+
+    Computes and plots confusion matrix, False Positive Rate, False Negative Rate,
+    Accuracy, and F1 score of a classification.
 
     :param y_test: array, shape = [n_samples]. Ground truth (correct) target values.
-    :param y_pred: array, shape = [n_samples]. Estimated targets as returned by a classifier.
-    :param labels: List of labels (strings or integers) used to index the matrix, corresponding to n_classes.
-    :param sample_weight: array-like of shape = [n_samples], optional. Optional sample weights for weighting the samples.
-    :param annot_kws: dict of key, value mappings, optional. Keyword arguments for ``ax.text``.
+    :param y_pred: array, shape = [n_samples]. Estimated targets as returned by a
+    classifier.
+    :param labels: List of labels (strings or integers) used to index the matrix,
+    corresponding to n_classes.
+    :param sample_weight: array-like of shape = [n_samples], optional. Optional sample
+    weights for weighting the samples.
+    :param annot_kws: dict of key, value mappings, optional. Keyword arguments for
+    ``ax.text``.
     :param cbar: boolean, optional. Whether to draw a colorbar.
-    :param cbar_kws: dict of key, value mappings, optional. Keyword arguments for ``figure.colorbar``.
-    :param kwargs: other keyword arguments. All other keyword arguments are passed to ``matplotlib.axes.Axes.pcolormesh()``.
+    :param cbar_kws: dict of key, value mappings, optional. Keyword arguments for
+    ``figure.colorbar``.
+    :param kwargs: other keyword arguments. All other keyword arguments are passed to
+    ``matplotlib.axes.Axes.pcolormesh()``.
     :return: Returns the Axes object with the matrix drawn onto it.
     """
     if len(labels) < 2:
         raise ValueError("Number of labels must be greater than 1")
 
-    cnf_matrix = confusion_matrix(y_test, y_pred, labels=labels, sample_weight=sample_weight)
+    cnf_matrix = confusion_matrix(
+        y_test, y_pred, labels=labels, sample_weight=sample_weight
+    )
     if len(labels) == 2:
         df, tnr, tpr = _create_binary_confusion_matrix(cnf_matrix, labels)
     else:
         df, tnr, tpr = _create_multiclass_confusion_matrix(cnf_matrix, labels)
 
-    subplots = _plot_confusion_matrix_helper(df, tnr, tpr, labels, y_pred, y_test, sample_weight, annot_kws, cbar,
-                                             cbar_kws, kwargs)
+    subplots = _plot_confusion_matrix_helper(
+        df,
+        tnr,
+        tpr,
+        labels,
+        y_pred,
+        y_test,
+        sample_weight,
+        annot_kws,
+        cbar,
+        cbar_kws,
+        kwargs,
+    )
     return subplots
 
 
@@ -63,42 +85,61 @@ def _calc_precision_recall(
         fn: Union[float, np.ndarray],
         fp: Union[float, np.ndarray],
         tn: Union[float, np.ndarray],
-        tp: Union[float, np.ndarray]
-) -> Tuple[Union[float, np.ndarray], Union[float, np.ndarray], Union[float, np.ndarray], Union[float, np.ndarray]]:
-    tpr = (tp / (tp + fn))
-    tnr = (tn / (tn + fp))
-    npv = (tn / (tn + fn))
-    ppv = (tp / (tp + fp))
+        tp: Union[float, np.ndarray],
+) -> Tuple[
+    Union[float, np.ndarray],
+    Union[float, np.ndarray],
+    Union[float, np.ndarray],
+    Union[float, np.ndarray],
+]:
+    tpr = tp / (tp + fn)
+    tnr = tn / (tn + fp)
+    npv = tn / (tn + fn)
+    ppv = tp / (tp + fp)
     return npv, ppv, tnr, tpr
 
 
 def _create_multiclass_confusion_matrix(
-        cnf_matrix: np.ndarray,
-        labels: List[Union[str, int]]
+        cnf_matrix: np.ndarray, labels: List[Union[str, int]]
 ) -> Tuple[pd.DataFrame, Union[float, np.ndarray], Union[float, np.ndarray]]:
     fp = (cnf_matrix.sum(axis=0) - np.diag(cnf_matrix)).astype(float)
     fn = (cnf_matrix.sum(axis=1) - np.diag(cnf_matrix)).astype(float)
     tp = (np.diag(cnf_matrix)).astype(float)
     tn = (cnf_matrix.sum() - (fp + fn + tp)).astype(float)
     _, ppv, tnr, tpr = _calc_precision_recall(fn, fp, tn, tp)
-    df = pd.DataFrame(cnf_matrix, columns=[f"{label} - Predicted" for label in labels],
-                      index=[f"{label} - Actual" for label in labels])
+    df = pd.DataFrame(
+        cnf_matrix,
+        columns=[f"{label} - Predicted" for label in labels],
+        index=[f"{label} - Actual" for label in labels],
+    )
     df["Recall"] = tpr
     df = pd.concat(
-        [df, pd.DataFrame([ppv], columns=[f"{label} - Predicted" for label in labels], index=["Precision"])],
-        sort=False)
+        [
+            df,
+            pd.DataFrame(
+                [ppv],
+                columns=[f"{label} - Predicted" for label in labels],
+                index=["Precision"],
+            ),
+        ],
+        sort=False,
+    )
     return df, tnr, tpr
 
 
 def _create_binary_confusion_matrix(
-        cnf_matrix: np.ndarray,
-        labels: List[Union[str, int]]
+        cnf_matrix: np.ndarray, labels: List[Union[str, int]]
 ) -> Tuple[pd.DataFrame, float, float]:
     tn, fp, fn, tp = cnf_matrix.ravel()
     npv, ppv, tnr, tpr = _calc_precision_recall(fn, fp, tn, tp)
-    table = np.array([[tn, fp, tnr], [fn, tp, tpr], [npv, ppv, np.nan]], dtype=np.float64)
-    df = pd.DataFrame(table, columns=[f"{labels[0]} - Predicted", f"{labels[1]} - Predicted", "Recall"],
-                      index=[f"{labels[0]} - Actual", f"{labels[1]} - Actual", "Precision"])
+    table = np.array(
+        [[tn, fp, tnr], [fn, tp, tpr], [npv, ppv, np.nan]], dtype=np.float64
+    )
+    df = pd.DataFrame(
+        table,
+        columns=[f"{labels[0]} - Predicted", f"{labels[1]} - Predicted", "Recall"],
+        index=[f"{labels[0]} - Actual", f"{labels[1]} - Actual", "Precision"],
+    )
     return df, tnr, tpr
 
 
@@ -113,27 +154,59 @@ def _plot_confusion_matrix_helper(
         annot_kws: Optional[Dict],
         cbar: bool,
         cbar_kws: Optional[Dict],
-        kwargs
+        kwargs,
 ) -> axes.Axes:
-    figure, subplots = plt.subplots(nrows=3, ncols=1, gridspec_kw={'height_ratios': [1, 8, 1]})
+    figure, subplots = plt.subplots(
+        nrows=3, ncols=1, gridspec_kw={"height_ratios": [1, 8, 1]}
+    )
     subplots = subplots.flatten()
     subplots[0].set_axis_off()
     if len(labels) == 2:
         subplots[0].text(0, 0.85, f"False Positive Rate: {1 - tnr:.4f}")
         subplots[0].text(0, 0.35, f"False Negative Rate: {1 - tpr:.4f}")
     else:
-        subplots[0].text(0, 0.85, f"False Positive Rate: {np.array2string(1 - tnr, precision=2, separator=',')}")
-        subplots[0].text(0, 0.35, f"False Negative Rate: {np.array2string(1 - tpr, precision=2, separator=',')}")
+        subplots[0].text(
+            0,
+            0.85,
+            f"False Positive Rate: "
+            f"{np.array2string(1 - tnr, precision=2, separator=',')}",
+        )
+        subplots[0].text(
+            0,
+            0.35,
+            f"False Negative Rate: "
+            f"{np.array2string(1 - tpr, precision=2, separator=',')}",
+        )
     subplots[0].text(0, -0.5, "Confusion Matrix:")
-    sns.heatmap(df, annot=True, fmt=".3f", ax=subplots[1], annot_kws=annot_kws, cbar=cbar, cbar_kws=cbar_kws,
-                **kwargs)
+    sns.heatmap(
+        df,
+        annot=True,
+        fmt=".3f",
+        ax=subplots[1],
+        annot_kws=annot_kws,
+        cbar=cbar,
+        cbar_kws=cbar_kws,
+        **kwargs,
+    )
     subplots[2].set_axis_off()
-    subplots[2].text(0, 0.15, f"Accuracy: {accuracy_score(y_test, y_pred, sample_weight=sample_weight):.4f}")
+    subplots[2].text(
+        0,
+        0.15,
+        f"Accuracy: {accuracy_score(y_test, y_pred, sample_weight=sample_weight):.4f}",
+    )
     if len(labels) == 2:
-        f_score = f1_score(y_test, y_pred, labels=labels, pos_label=labels[1], average="binary",
-                           sample_weight=sample_weight)
+        f_score = f1_score(
+            y_test,
+            y_pred,
+            labels=labels,
+            pos_label=labels[1],
+            average="binary",
+            sample_weight=sample_weight,
+        )
     else:
-        f_score = f1_score(y_test, y_pred, labels=labels, average="micro", sample_weight=sample_weight)
+        f_score = f1_score(
+            y_test, y_pred, labels=labels, average="micro", sample_weight=sample_weight
+        )
     subplots[2].text(0, -0.5, f"F1 Score: {f_score:.4f}")
     return subplots
 
@@ -153,25 +226,37 @@ def plot_metric_growth_per_labeled_instances(
         pre_dispatch: Optional[Union[int, str]] = "2*n_jobs",
         *,
         ax: Optional[axes.Axes] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
-    """
-    Receives train and test sets, and plots the change in the given metric with increasing amounts of trained instances.
+    """Plot learning curves showing metric performance vs training set size.
 
-    :param X_train: array-like or sparse matrix of shape (n_samples, n_features). The training input samples.
-    :param y_train: array-like of shape (n_samples,). The target values (class labels) as integers or strings.
-    :param X_test: array-like or sparse matrix of shape (n_samples, n_features). The test or evaluation input samples.
+    Receives train and test sets, and plots the change in the given metric with
+
+
+    :param X_train: array-like or sparse matrix of shape (n_samples, n_features).
+    The training input samples.
+    :param y_train: array-like of shape (n_samples,). The target values (class labels)
+    as integers or strings.
+    :param X_test: array-like or sparse matrix of shape (n_samples, n_features).
+    The test or evaluation input samples.
     :param y_test: array-like of shape (n_samples,). The true labels for X_test.
-    :param classifiers_dict: mapping from classifier name to classifier object.
-    :param n_samples: List of numbers of samples for training batches, optional (default=None).
-    :param quantiles: List of percentages of samples for training batches, optional (default=[0.05, 0.1, ..., 0.95, 1]).
+    :param classifiers_dict: mapping from classifier name to a classifier object.
+    :param n_samples: List of numbers of samples for training batches,
+    optional (default=None).
+    :param quantiles: Percentages' list samples for training batches,
+    optional (default=[0.05, 0.1, ..., 0.95, 1]).
                       Used when n_samples=None.
-    :param metric: sklearn.metrics API function which receives y_true and y_pred and returns float.
+    :param metric: sklearn.metrics API function which receives y_true and y_pred and
+    returns float.
     :param random_state: int, RandomState instance or None, optional (default=None).
-                         Controls the shuffling applied to the data before applying the split.
-    :param n_jobs: int or None, optional (default=None). The number of jobs to run in parallel.
-    :param verbose: int, optional (default=0). Controls the verbosity when fitting and predicting.
-    :param pre_dispatch: int or string, optional. Controls the number of jobs that get dispatched during parallel execution.
+                         Controls the shuffling applied to the data before applying the
+                         split.
+    :param n_jobs: int or None, optional (default=None). The number of jobs to run in
+    parallel.
+    :param verbose: int, optional (default=0). Controls the verbosity when fitting and
+    predicting.
+    :param pre_dispatch: int or string, optional. Controls the number of jobs that get
+    dispatched during parallel execution.
     :param ax: matplotlib Axes object, optional. The axes to plot on.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Axes object with the plot drawn onto it.
@@ -179,7 +264,11 @@ def plot_metric_growth_per_labeled_instances(
     if ax is None:
         _, ax = plt.subplots()
 
-    random_state = RandomState(random_state) if not isinstance(random_state, RandomState) else random_state
+    random_state = (
+        RandomState(random_state)
+        if not isinstance(random_state, RandomState)
+        else random_state
+    )
 
     if n_samples is None:
         if quantiles is not None:
@@ -190,16 +279,28 @@ def plot_metric_growth_per_labeled_instances(
     parallel = Parallel(n_jobs=n_jobs, verbose=verbose, pre_dispatch=pre_dispatch)
 
     classifiers_dict_results = dict()
-    samples_list = [shuffle(X_train, y_train, random_state=random_state, n_samples=n_sample) for n_sample in n_samples]
+    samples_list = [
+        shuffle(X_train, y_train, random_state=random_state, n_samples=n_sample)
+        for n_sample in n_samples
+    ]
 
     with parallel:
         for classifier_name, classifier in classifiers_dict.items():
             if verbose > 0:
-                print(f"Fitting classifier {classifier_name} for {len(n_samples)} times")
+                print(
+                    f"Fitting classifier {classifier_name} for {len(n_samples)} times"
+                )
             scores = parallel(
                 delayed(_perform_data_partition_and_evaluation)(
-                    x_train_part, y_train_part, X_test, y_test, clone(classifier), metric
-                ) for x_train_part, y_train_part in samples_list)
+                    x_train_part,
+                    y_train_part,
+                    X_test,
+                    y_test,
+                    clone(classifier),
+                    metric,
+                )
+                for x_train_part, y_train_part in samples_list
+            )
             classifiers_dict_results[classifier_name] = scores
 
     for classifier_name, scores in classifiers_dict_results.items():
@@ -218,7 +319,7 @@ def _perform_data_partition_and_evaluation(
         X_test: np.ndarray,
         y_test: np.ndarray,
         classifier: ClassifierMixin,
-        metric: Callable[[np.ndarray, np.ndarray], float]
+        metric: Callable[[np.ndarray, np.ndarray], float],
 ) -> float:
     if y_train.shape[1] == 1:
         classifier.fit(X_train, y_train.ravel())
@@ -237,51 +338,75 @@ def visualize_accuracy_grouped_by_probability(
         bins: Optional[Union[int, Sequence[float], pd.IntervalIndex]] = None,
         *,
         ax: Optional[axes.Axes] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
-    """
-    Receives true test labels and classifier probability predictions, divides and classifies the results,
-    and finally plots a stacked bar chart with the results. `Original code <https://github.com/EthicalML/XAI>`_
+    """Plot a stacked bar chart of classifier results by probability bins.
+
+    Receives true test labels and classifier probability predictions, divides and
+    classifies the results, and finally plots a stacked bar chart with the results.
+    `Original code <https://github.com/EthicalML/XAI>`_.
 
     :param y_test: array, shape = [n_samples]. Ground truth (correct) target values.
     :param labeled_class: the class to inquire about.
-    :param probabilities: array, shape = [n_samples]. Classifier probabilities for the labeled class.
+    :param probabilities: array, shape = [n_samples]. Classifier probabilities for the
+    labeled class.
     :param threshold: the probability threshold for classifying the labeled class.
-    :param display_breakdown: if True, the results will be displayed as "correct" and "incorrect";
-                              otherwise as "true-positives", "true-negatives", "false-positives" and "false-negatives".
+    :param display_breakdown: if True, the results will be displayed as "correct" and
+    "incorrect"; otherwise as "true-positives", "true-negatives", "false-positives"
+    and "false-negatives".
     :param bins: int, sequence of scalars, or IntervalIndex. The criteria to bin by.
     :param ax: matplotlib Axes object, optional. The axes to plot on.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Axes object with the plot drawn onto it.
     """
-
     if bins is None:
         bins = [0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
 
     if ax is None:
         _, ax = plt.subplots()
 
-    df_results = pd.DataFrame({
-        "Actual Class": np.vectorize(lambda x: x == labeled_class)(y_test),
-        "Probability": probabilities,
-        "Prediction": probabilities > threshold
-    })
+    df_results = pd.DataFrame(
+        {
+            "Actual Class": np.vectorize(lambda x: x == labeled_class)(y_test),
+            "Probability": probabilities,
+            "Prediction": probabilities > threshold,
+        }
+    )
 
-    df_results["True Positive"] = (df_results["Actual Class"] & df_results["Prediction"]).astype(int)
-    df_results["True Negative"] = (~df_results["Actual Class"] & ~df_results["Prediction"]).astype(int)
-    df_results["False Positive"] = (~df_results["Actual Class"] & df_results["Prediction"]).astype(int)
-    df_results["False Negative"] = (df_results["Actual Class"] & ~df_results["Prediction"]).astype(int)
+    df_results["True Positive"] = (
+            df_results["Actual Class"] & df_results["Prediction"]
+    ).astype(int)
+    df_results["True Negative"] = (
+            ~df_results["Actual Class"] & ~df_results["Prediction"]
+    ).astype(int)
+    df_results["False Positive"] = (
+            ~df_results["Actual Class"] & df_results["Prediction"]
+    ).astype(int)
+    df_results["False Negative"] = (
+            df_results["Actual Class"] & ~df_results["Prediction"]
+    ).astype(int)
 
     if display_breakdown:
-        df_results["Correct"] = df_results["True Positive"] + df_results["True Negative"]
-        df_results["Incorrect"] = df_results["False Positive"] + df_results["False Negative"]
+        df_results["Correct"] = (
+                df_results["True Positive"] + df_results["True Negative"]
+        )
+        df_results["Incorrect"] = (
+                df_results["False Positive"] + df_results["False Negative"]
+        )
         display_columns = ["Correct", "Incorrect"]
     else:
-        display_columns = ["True Positive", "True Negative", "False Positive", "False Negative"]
+        display_columns = [
+            "True Positive",
+            "True Negative",
+            "False Positive",
+            "False Negative",
+        ]
 
     # Group the results by probability bins
     df_results["Probability Bin"] = pd.cut(df_results["Probability"], bins=bins)
-    grouped_results = df_results.groupby("Probability Bin", observed=False)[display_columns].sum()
+    grouped_results = df_results.groupby("Probability Bin", observed=False)[
+        display_columns
+    ].sum()
 
     # Plot the results
     grouped_results.plot(kind="bar", stacked=True, ax=ax, **kwargs)
@@ -294,7 +419,7 @@ def visualize_accuracy_grouped_by_probability(
     ax.legend(title="Prediction Type")
 
     # Rotate x-axis labels for better readability
-    plt.setp(ax.get_xticklabels(), rotation=45, ha='right')
+    plt.setp(ax.get_xticklabels(), rotation=45, ha="right")
 
     # Adjust layout to prevent cutting off labels
     plt.tight_layout()
@@ -309,31 +434,40 @@ def plot_roc_curve_with_thresholds_annotations(
         positive_label: Optional[Union[int, float, bool, str]] = None,
         sample_weight: Optional[np.ndarray] = None,
         drop_intermediate: bool = True,
-        average: Optional[str] = 'macro',
+        average: Optional[str] = "macro",
         max_fpr: Optional[float] = None,
-        multi_class: str = 'raise',
+        multi_class: str = "raise",
         labels: Optional[np.ndarray] = None,
         fig: Optional[go.Figure] = None,
-        mode: Optional[str] = 'lines+markers',
+        mode: Optional[str] = "lines+markers",
         add_random_classifier_line: bool = True,
         show_legend: bool = True,
-        **kwargs
+        **kwargs,
 ) -> go.Figure:
-    """
-    Plot ROC curves with threshold annotations for multiple classifiers.
+    """Plot ROC curves with threshold annotations for multiple classifiers.
 
     :param y_true: array-like of shape (n_samples,). True binary labels.
-    :param classifiers_names_and_scores_dict: mapping from classifier name to classifier's score.
-    :param positive_label: int, float, bool or str, default=None. The label of the positive class.
-    :param sample_weight: array-like of shape (n_samples,), default=None. Sample weights.
-    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal thresholds which would not appear on a plotted ROC curve.
-    :param average: {'micro', 'macro', 'samples', 'weighted'} or None, default='macro'. If not None, this determines the type of averaging performed on the data.
-    :param max_fpr: float > 0 and <= 1, default=None. If not None, the standardized partial AUC over the range [0, max_fpr] is returned.
-    :param multi_class: {'raise', 'ovr', 'ovo'}, default='raise'. Determines the type of configuration to use for multiclass targets.
-    :param labels: array-like of shape (n_classes,), default=None. Only used for multiclass targets. List of labels that index the classes in y_score.
+    :param classifiers_names_and_scores_dict: mapping from classifier name to
+    classifier's score.
+    :param positive_label: int, float, bool or str, default=None. The label of the
+    positive class.
+    :param sample_weight: array-like of shape (n_samples,), default=None.
+    Sample weights.
+    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal
+    thresholds that would not appear on a plotted ROC curve.
+    :param average: {'micro', 'macro', 'samples', 'weighted'} or None, default='macro'.
+    If not None, this determines the type of averaging performed on the data.
+    :param max_fpr: float > 0 and <= 1, default=None. If not None, the standardized
+    partial AUC over the range [0, max_fpr] is returned.
+    :param multi_class: {'raise', 'ovr', 'ovo'}, default='raise'. Determines the type
+    of configuration to use for multiclass targets.
+    :param labels: array-like of shape (n_classes,), default=None. Only used for
+    multiclass targets. List of labels that index the classes in y_score.
     :param fig: plotly's Figure object, optional. The figure to plot on.
-    :param mode: str, default='lines+markers'. Determines the drawing mode for this scatter trace.
-    :param add_random_classifier_line: bool, default=True. Whether to plot a diagonal dashed black line which represents a random classifier.
+    :param mode: str, default='lines+markers'. Determines the drawing mode for this
+    scatter trace.
+    :param add_random_classifier_line: bool, default=True. Whether to plot a diagonal
+    dashed black line which represents a random classifier.
     :param show_legend: bool, default=True. Whether to display legend in the plot.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Figure object with the plot drawn onto it.
@@ -345,33 +479,53 @@ def plot_roc_curve_with_thresholds_annotations(
     for classifier_name, y_scores in classifiers_names_and_scores_dict.items():
         if y_true.shape != y_scores.shape:
             raise ValueError(
-                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} for classifier {classifier_name}")
+                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} "
+                f"for classifier {classifier_name}"
+            )
 
         try:
-            fpr_array, tpr_array, thresholds = roc_curve(y_true, y_scores, pos_label=positive_label,
-                                                         sample_weight=sample_weight,
-                                                         drop_intermediate=drop_intermediate)
+            fpr_array, tpr_array, thresholds = roc_curve(
+                y_true,
+                y_scores,
+                pos_label=positive_label,
+                sample_weight=sample_weight,
+                drop_intermediate=drop_intermediate,
+            )
         except ValueError as e:
-            raise ValueError(f"Error calculating ROC curve for classifier {classifier_name}: {str(e)}")
+            raise ValueError(
+                f"Error calculating ROC curve for classifier {classifier_name}: "
+                f"{str(e)}"
+            )
 
         try:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", category=UndefinedMetricWarning)
-                auc_score = roc_auc_score(y_true, y_scores, average=average, sample_weight=sample_weight,
-                                          max_fpr=max_fpr,
-                                          multi_class=multi_class, labels=labels)
+                auc_score = roc_auc_score(
+                    y_true,
+                    y_scores,
+                    average=average,
+                    sample_weight=sample_weight,
+                    max_fpr=max_fpr,
+                    multi_class=multi_class,
+                    labels=labels,
+                )
         except ValueError as e:
-            raise ValueError(f"Error calculating AUC score for classifier {classifier_name}: {str(e)}")
+            raise ValueError(
+                f"Error calculating AUC score for classifier {classifier_name}: "
+                f"{str(e)}"
+            )
 
         fig.add_trace(
             go.Scatter(
                 x=fpr_array,
                 y=tpr_array,
                 mode=mode,
-                text=[f'Prob: {threshold:.2f}<br>FPR: {fpr:.2f}<br>TPR: {tpr:.2f}' for fpr, tpr, threshold in
-                      zip(fpr_array, tpr_array, thresholds)],
+                text=[
+                    f"Prob: {threshold:.2f}<br>FPR: {fpr:.2f}<br>TPR: {tpr:.2f}"
+                    for fpr, tpr, threshold in zip(fpr_array, tpr_array, thresholds)
+                ],
                 name=f"{classifier_name} (AUC = {auc_score:.2f})",
-                **kwargs
+                **kwargs,
             )
         )
 
@@ -380,16 +534,16 @@ def plot_roc_curve_with_thresholds_annotations(
             go.Scatter(
                 x=[0, 1],
                 y=[0, 1],
-                mode='lines',
-                line=dict(dash='dash', color='black'),
-                name="Random Classifier"
+                mode="lines",
+                line=dict(dash="dash", color="black"),
+                name="Random Classifier",
             )
         )
 
     fig.update_layout(
         xaxis_title="False Positive Rate",
         yaxis_title="True Positive Rate",
-        showlegend=show_legend
+        showlegend=show_legend,
     )
 
     return fig
@@ -403,22 +557,27 @@ def plot_precision_recall_curve_with_thresholds_annotations(
         sample_weight: Optional[np.ndarray] = None,
         drop_intermediate: bool = True,
         fig: Optional[go.Figure] = None,
-        mode: Optional[str] = 'lines+markers',
+        mode: Optional[str] = "lines+markers",
         add_random_classifier_line: bool = False,
         show_legend: bool = True,
-        **kwargs
+        **kwargs,
 ) -> go.Figure:
-    """
-    Plot Precision-Recall curves with threshold annotations for multiple classifiers.
+    """Plot Precision-Recall curves with threshold annotations for multiple classifiers.
 
     :param y_true: array-like of shape (n_samples,). True binary labels.
-    :param classifiers_names_and_scores_dict: mapping from classifier name to classifier's score.
-    :param positive_label: int, float, bool or str, default=None. The label of the positive class.
-    :param sample_weight: array-like of shape (n_samples,), default=None. Sample weights.
-    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal thresholds which would not appear on a plotted Precision-Recall curve.
+    :param classifiers_names_and_scores_dict: mapping from classifier name to
+    classifier's score.
+    :param positive_label: int, float, bool or str, default=None. The label of the
+    positive class.
+    :param sample_weight: array-like of shape (n_samples,), default=None.
+    Sample weights.
+    :param drop_intermediate: bool, default=True. Whether to drop some suboptimal
+    thresholds that would not appear on a plotted Precision-Recall curve.
     :param fig: plotly's Figure object, optional. The figure to plot on.
-    :param mode: str, default='lines+markers'. Determines the drawing mode for this scatter trace.
-    :param add_random_classifier_line: bool, default=False. Whether to plot a diagonal dashed black line which represents a random classifier.
+    :param mode: str, default='lines+markers'. Determines the drawing mode for this
+    scatter trace.
+    :param add_random_classifier_line: bool, default=False. Whether to plot a diagonal
+    dashed black line which represents a random classifier.
     :param show_legend: bool, default=True. Whether to display legend in the plot.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Figure object with the plot drawn onto it.
@@ -430,24 +589,37 @@ def plot_precision_recall_curve_with_thresholds_annotations(
     for classifier_name, y_scores in classifiers_names_and_scores_dict.items():
         if y_true.shape != y_scores.shape:
             raise ValueError(
-                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} for classifier {classifier_name}")
+                f"Shape mismatch: y_true {y_true.shape} and y_scores {y_scores.shape} "
+                f"for classifier {classifier_name}"
+            )
         try:
-            precision_array, recall_array, thresholds = precision_recall_curve(y_true, y_scores,
-                                                                               pos_label=positive_label,
-                                                                               sample_weight=sample_weight,
-                                                                               drop_intermediate=drop_intermediate)
+            precision_array, recall_array, thresholds = precision_recall_curve(
+                y_true,
+                y_scores,
+                pos_label=positive_label,
+                sample_weight=sample_weight,
+                drop_intermediate=drop_intermediate,
+            )
         except ValueError as e:
-            raise ValueError(f"Error calculating Precision-Recall curve for classifier {classifier_name}: {str(e)}")
+            raise ValueError(
+                f"Error calculating Precision-Recall curve for classifier "
+                f"{classifier_name}: {str(e)}"
+            )
 
         fig.add_trace(
             go.Scatter(
                 x=recall_array,
                 y=precision_array,
                 mode=mode,
-                text=[f'Prob: {threshold:.2f}<br>Precision: {precision:.2f}<br>Recall: {recall:.2f}' for
-                      precision, recall, threshold in zip(precision_array, recall_array, thresholds)],
+                text=[
+                    f"Prob: {threshold:.2f}<br>Precision: {precision:.2f}<br>"
+                    f"Recall: {recall:.2f}"
+                    for precision, recall, threshold in zip(
+                        precision_array, recall_array, thresholds
+                    )
+                ],
                 name=classifier_name,
-                **kwargs
+                **kwargs,
             )
         )
 
@@ -456,16 +628,14 @@ def plot_precision_recall_curve_with_thresholds_annotations(
             go.Scatter(
                 x=[1, 0],
                 y=[0, 1],
-                mode='lines',
-                line=dict(dash='dash', color='black'),
-                name="Random Classifier"
+                mode="lines",
+                line=dict(dash="dash", color="black"),
+                name="Random Classifier",
             )
         )
 
     fig.update_layout(
-        xaxis_title="Recall",
-        yaxis_title="Precision",
-        showlegend=show_legend
+        xaxis_title="Recall", yaxis_title="Precision", showlegend=show_legend
     )
 
     return fig

--- a/ds_utils/metrics.py
+++ b/ds_utils/metrics.py
@@ -17,14 +17,14 @@ from sklearn.utils import shuffle
 
 
 def plot_confusion_matrix(
-        y_test: np.ndarray,
-        y_pred: np.ndarray,
-        labels: List[Union[str, int]],
-        sample_weight: Optional[List[float]] = None,
-        annot_kws: Optional[Dict] = None,
-        cbar: bool = True,
-        cbar_kws: Optional[Dict] = None,
-        **kwargs,
+    y_test: np.ndarray,
+    y_pred: np.ndarray,
+    labels: List[Union[str, int]],
+    sample_weight: Optional[List[float]] = None,
+    annot_kws: Optional[Dict] = None,
+    cbar: bool = True,
+    cbar_kws: Optional[Dict] = None,
+    **kwargs,
 ) -> axes.Axes:
     """Compute and plot confusion matrix with classification metrics.
 
@@ -59,10 +59,10 @@ def plot_confusion_matrix(
 
 
 def _calc_precision_recall(
-        fn: Union[float, np.ndarray],
-        fp: Union[float, np.ndarray],
-        tn: Union[float, np.ndarray],
-        tp: Union[float, np.ndarray],
+    fn: Union[float, np.ndarray],
+    fp: Union[float, np.ndarray],
+    tn: Union[float, np.ndarray],
+    tp: Union[float, np.ndarray],
 ) -> Tuple[Union[float, np.ndarray], Union[float, np.ndarray], Union[float, np.ndarray], Union[float, np.ndarray]]:
     tpr = tp / (tp + fn)
     tnr = tn / (tn + fp)
@@ -72,7 +72,7 @@ def _calc_precision_recall(
 
 
 def _create_multiclass_confusion_matrix(
-        cnf_matrix: np.ndarray, labels: List[Union[str, int]]
+    cnf_matrix: np.ndarray, labels: List[Union[str, int]]
 ) -> Tuple[pd.DataFrame, Union[float, np.ndarray], Union[float, np.ndarray]]:
     fp = (cnf_matrix.sum(axis=0) - np.diag(cnf_matrix)).astype(float)
     fn = (cnf_matrix.sum(axis=1) - np.diag(cnf_matrix)).astype(float)
@@ -92,7 +92,7 @@ def _create_multiclass_confusion_matrix(
 
 
 def _create_binary_confusion_matrix(
-        cnf_matrix: np.ndarray, labels: List[Union[str, int]]
+    cnf_matrix: np.ndarray, labels: List[Union[str, int]]
 ) -> Tuple[pd.DataFrame, float, float]:
     tn, fp, fn, tp = cnf_matrix.ravel()
     npv, ppv, tnr, tpr = _calc_precision_recall(fn, fp, tn, tp)
@@ -106,17 +106,17 @@ def _create_binary_confusion_matrix(
 
 
 def _plot_confusion_matrix_helper(
-        df: pd.DataFrame,
-        tnr: Union[float, np.ndarray],
-        tpr: Union[float, np.ndarray],
-        labels: List[Union[str, int]],
-        y_pred: np.ndarray,
-        y_test: np.ndarray,
-        sample_weight: Optional[List[float]],
-        annot_kws: Optional[Dict],
-        cbar: bool,
-        cbar_kws: Optional[Dict],
-        kwargs,
+    df: pd.DataFrame,
+    tnr: Union[float, np.ndarray],
+    tpr: Union[float, np.ndarray],
+    labels: List[Union[str, int]],
+    y_pred: np.ndarray,
+    y_test: np.ndarray,
+    sample_weight: Optional[List[float]],
+    annot_kws: Optional[Dict],
+    cbar: bool,
+    cbar_kws: Optional[Dict],
+    kwargs,
 ) -> axes.Axes:
     figure, subplots = plt.subplots(nrows=3, ncols=1, gridspec_kw={"height_ratios": [1, 8, 1]})
     subplots = subplots.flatten()
@@ -142,21 +142,21 @@ def _plot_confusion_matrix_helper(
 
 
 def plot_metric_growth_per_labeled_instances(
-        X_train: np.ndarray,
-        y_train: np.ndarray,
-        X_test: np.ndarray,
-        y_test: np.ndarray,
-        classifiers_dict: Dict[str, ClassifierMixin],
-        n_samples: Optional[List[int]] = None,
-        quantiles: Optional[List[float]] = np.linspace(0.05, 1, 20).tolist(),
-        metric: Callable[[np.ndarray, np.ndarray], float] = accuracy_score,
-        random_state: Optional[Union[int, RandomState]] = None,
-        n_jobs: Optional[int] = None,
-        verbose: int = 0,
-        pre_dispatch: Optional[Union[int, str]] = "2*n_jobs",
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs,
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+    classifiers_dict: Dict[str, ClassifierMixin],
+    n_samples: Optional[List[int]] = None,
+    quantiles: Optional[List[float]] = np.linspace(0.05, 1, 20).tolist(),
+    metric: Callable[[np.ndarray, np.ndarray], float] = accuracy_score,
+    random_state: Optional[Union[int, RandomState]] = None,
+    n_jobs: Optional[int] = None,
+    verbose: int = 0,
+    pre_dispatch: Optional[Union[int, str]] = "2*n_jobs",
+    *,
+    ax: Optional[axes.Axes] = None,
+    **kwargs,
 ) -> axes.Axes:
     """Plot learning curves showing metric performance vs training set size.
 
@@ -221,12 +221,12 @@ def plot_metric_growth_per_labeled_instances(
 
 
 def _perform_data_partition_and_evaluation(
-        X_train: np.ndarray,
-        y_train: np.ndarray,
-        X_test: np.ndarray,
-        y_test: np.ndarray,
-        classifier: ClassifierMixin,
-        metric: Callable[[np.ndarray, np.ndarray], float],
+    X_train: np.ndarray,
+    y_train: np.ndarray,
+    X_test: np.ndarray,
+    y_test: np.ndarray,
+    classifier: ClassifierMixin,
+    metric: Callable[[np.ndarray, np.ndarray], float],
 ) -> float:
     if y_train.shape[1] == 1:
         classifier.fit(X_train, y_train.ravel())
@@ -237,15 +237,15 @@ def _perform_data_partition_and_evaluation(
 
 
 def visualize_accuracy_grouped_by_probability(
-        y_test: np.ndarray,
-        labeled_class: Union[str, int],
-        probabilities: np.ndarray,
-        threshold: float = 0.5,
-        display_breakdown: bool = False,
-        bins: Optional[Union[int, Sequence[float], pd.IntervalIndex]] = None,
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs,
+    y_test: np.ndarray,
+    labeled_class: Union[str, int],
+    probabilities: np.ndarray,
+    threshold: float = 0.5,
+    display_breakdown: bool = False,
+    bins: Optional[Union[int, Sequence[float], pd.IntervalIndex]] = None,
+    *,
+    ax: Optional[axes.Axes] = None,
+    **kwargs,
 ) -> axes.Axes:
     """Plot a stacked bar chart of classifier results by probability bins.
 
@@ -314,21 +314,21 @@ def visualize_accuracy_grouped_by_probability(
 
 
 def plot_roc_curve_with_thresholds_annotations(
-        y_true: np.ndarray,
-        classifiers_names_and_scores_dict: Dict[str, np.ndarray],
-        *,
-        positive_label: Optional[Union[int, float, bool, str]] = None,
-        sample_weight: Optional[np.ndarray] = None,
-        drop_intermediate: bool = True,
-        average: Optional[str] = "macro",
-        max_fpr: Optional[float] = None,
-        multi_class: str = "raise",
-        labels: Optional[np.ndarray] = None,
-        fig: Optional[go.Figure] = None,
-        mode: Optional[str] = "lines+markers",
-        add_random_classifier_line: bool = True,
-        show_legend: bool = True,
-        **kwargs,
+    y_true: np.ndarray,
+    classifiers_names_and_scores_dict: Dict[str, np.ndarray],
+    *,
+    positive_label: Optional[Union[int, float, bool, str]] = None,
+    sample_weight: Optional[np.ndarray] = None,
+    drop_intermediate: bool = True,
+    average: Optional[str] = "macro",
+    max_fpr: Optional[float] = None,
+    multi_class: str = "raise",
+    labels: Optional[np.ndarray] = None,
+    fig: Optional[go.Figure] = None,
+    mode: Optional[str] = "lines+markers",
+    add_random_classifier_line: bool = True,
+    show_legend: bool = True,
+    **kwargs,
 ) -> go.Figure:
     """Plot ROC curves with threshold annotations for multiple classifiers.
 
@@ -417,17 +417,17 @@ def plot_roc_curve_with_thresholds_annotations(
 
 
 def plot_precision_recall_curve_with_thresholds_annotations(
-        y_true: np.ndarray,
-        classifiers_names_and_scores_dict: Dict[str, np.ndarray],
-        *,
-        positive_label: Optional[Union[int, float, bool, str]] = None,
-        sample_weight: Optional[np.ndarray] = None,
-        drop_intermediate: bool = True,
-        fig: Optional[go.Figure] = None,
-        mode: Optional[str] = "lines+markers",
-        add_random_classifier_line: bool = False,
-        show_legend: bool = True,
-        **kwargs,
+    y_true: np.ndarray,
+    classifiers_names_and_scores_dict: Dict[str, np.ndarray],
+    *,
+    positive_label: Optional[Union[int, float, bool, str]] = None,
+    sample_weight: Optional[np.ndarray] = None,
+    drop_intermediate: bool = True,
+    fig: Optional[go.Figure] = None,
+    mode: Optional[str] = "lines+markers",
+    add_random_classifier_line: bool = False,
+    show_legend: bool = True,
+    **kwargs,
 ) -> go.Figure:
     """Plot Precision-Recall curves with threshold annotations for multiple classifiers.
 

--- a/ds_utils/metrics.py
+++ b/ds_utils/metrics.py
@@ -42,6 +42,8 @@ def plot_confusion_matrix(
     :param kwargs: other keyword arguments. All other keyword arguments are passed
                    to ``matplotlib.axes.Axes.pcolormesh()``.
     :return: Returns the Axes object with the matrix drawn onto it.
+
+    :raises ValueError: If number of labels is lower than 2.
     """
     if len(labels) < 2:
         raise ValueError("Number of labels must be greater than 1")
@@ -158,7 +160,7 @@ def plot_metric_growth_per_labeled_instances(
     ax: Optional[axes.Axes] = None,
     **kwargs,
 ) -> axes.Axes:
-    """Plot learning curves showing metric performance vs training set size.
+    """Plot learning curves showing metric performance vs. training set size.
 
     Receives train and test sets, and plots the change in the given metric with increasing numbers of trained
     instances.
@@ -181,6 +183,8 @@ def plot_metric_growth_per_labeled_instances(
     :param ax: matplotlib Axes object, optional. The axes to plot on.
     :param kwargs: additional keyword arguments to be passed to the plot function.
     :return: The Axes object with the plot drawn onto it.
+
+    :raises ValueError: If both n_samples and quantiles are None.
     """
     if ax is None:
         _, ax = plt.subplots()

--- a/ds_utils/preprocess.py
+++ b/ds_utils/preprocess.py
@@ -169,7 +169,7 @@ def plot_features_interaction(
 
 def _is_categorical_like(dtype):
     """Check if the dtype is categorical-like (categorical, boolean, or object)."""
-    return isinstance(dtype, pd.CategoricalDtype) or isinstance(dtype, bool) or dtype == object
+    return isinstance(dtype, pd.CategoricalDtype) or dtype == bool or dtype == object
 
 
 def _plot_categorical_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs):

--- a/ds_utils/preprocess.py
+++ b/ds_utils/preprocess.py
@@ -27,7 +27,7 @@ def visualize_feature(
 
     :param series: The data series to visualize.
     :param remove_na: If True, ignore NA values when plotting; if False, include them.
-    :param ax: Axes in which to draw the plot. If None, use the currently-active Axes.
+    :param ax: Axes in which to draw the plot. If None, use the currently active Axes.
     :param kwargs: Additional keyword arguments passed to the underlying plotting function.
     :return: The Axes object with the plot drawn onto it.
     """
@@ -104,7 +104,7 @@ def visualize_correlations(
     `Original Seaborn code <https://seaborn.pydata.org/examples/many_pairwise_correlations.html>`_
 
     :param correlation_matrix: The correlation matrix.
-    :param ax: Axes in which to draw the plot. If None, use the currently-active Axes.
+    :param ax: Axes in which to draw the plot. If None, use the currently active Axes.
     :param kwargs: Additional keyword arguments passed to seaborn's heatmap function.
     :return: The Axes object with the plot drawn onto it.
     """
@@ -130,7 +130,7 @@ def plot_correlation_dendrogram(
     :param correlation_matrix: The correlation matrix.
     :param cluster_distance_method: Method for calculating the distance between newly formed clusters.
                                     `Read more here <https://docs.scipy.org/doc/scipy/reference/generated/scipy.cluster.hierarchy.linkage.html>`_
-    :param ax: Axes in which to draw the plot. If None, use the currently-active Axes.
+    :param ax: Axes in which to draw the plot. If None, use the currently active Axes.
     :param kwargs: Additional keyword arguments passed to the dendrogram function.
     :return: The Axes object with the plot drawn onto it.
     """
@@ -157,7 +157,7 @@ def plot_features_interaction(
     :param data: The input DataFrame, where each feature is a column.
     :param feature_1: Name of the first feature.
     :param feature_2: Name of the second feature.
-    :param ax: Axes in which to draw the plot. If None, use the currently-active Axes.
+    :param ax: Axes in which to draw the plot. If None, use the currently active Axes.
     :param kwargs: Additional keyword arguments passed to the underlying plotting function.
     :return: The Axes object with the plot drawn onto it.
     """
@@ -167,49 +167,49 @@ def plot_features_interaction(
     dtype1 = data[feature_1].dtype
     dtype2 = data[feature_2].dtype
 
-    if is_categorical_like(dtype1):
-        plot_categorical_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs)
+    if _is_categorical_like(dtype1):
+        _plot_categorical_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs)
     elif pd.api.types.is_datetime64_any_dtype(dtype1):
-        plot_datetime_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs)
-    elif is_categorical_like(dtype2):
-        plot_categorical_feature2(feature_1, feature_2, data, ax, **kwargs)
+        _plot_datetime_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs)
+    elif _is_categorical_like(dtype2):
+        _plot_categorical_feature2(feature_1, feature_2, data, ax, **kwargs)
     elif pd.api.types.is_datetime64_any_dtype(dtype2):
-        plot_datetime_feature2(feature_1, feature_2, data, ax, **kwargs)
+        _plot_datetime_feature2(feature_1, feature_2, data, ax, **kwargs)
     else:
-        plot_numeric_features(feature_1, feature_2, data, ax, **kwargs)
+        _plot_numeric_features(feature_1, feature_2, data, ax, **kwargs)
 
     return ax
 
 
-def is_categorical_like(dtype):
+def _is_categorical_like(dtype):
     """Check if the dtype is categorical-like (categorical, boolean, or object)."""
     return isinstance(dtype, pd.CategoricalDtype) or dtype == bool or dtype == object
 
 
-def plot_categorical_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs):
+def _plot_categorical_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs):
     """Plot when the first feature is categorical-like."""
     dup_df = pd.DataFrame()
     dup_df[feature_1] = _copy_series_or_keep_top_10(data[feature_1])
 
-    if is_categorical_like(dtype2):
-        plot_categorical_vs_categorical(feature_1, feature_2, dup_df, data, ax, **kwargs)
+    if _is_categorical_like(dtype2):
+        _plot_categorical_vs_categorical(feature_1, feature_2, dup_df, data, ax, **kwargs)
     elif pd.api.types.is_datetime64_any_dtype(dtype2):
-        plot_categorical_vs_datetime(feature_1, feature_2, dup_df, data, ax, **kwargs)
+        _plot_categorical_vs_datetime(feature_1, feature_2, dup_df, data, ax, **kwargs)
     else:
-        plot_categorical_vs_numeric(feature_1, feature_2, dup_df, data, ax, **kwargs)
+        _plot_categorical_vs_numeric(feature_1, feature_2, dup_df, data, ax, **kwargs)
 
 
-def plot_datetime_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs):
+def _plot_datetime_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs):
     """Plot when the first feature is datetime."""
-    if is_categorical_like(dtype2):
-        plot_datetime_vs_categorical(feature_1, feature_2, data, ax, **kwargs)
+    if _is_categorical_like(dtype2):
+        _plot_datetime_vs_categorical(feature_1, feature_2, data, ax, **kwargs)
     else:
         ax.plot(data[feature_1], data[feature_2], **kwargs)
         ax.set_xlabel(feature_1)
         ax.set_ylabel(feature_2)
 
 
-def plot_categorical_feature2(feature_1, feature_2, data, ax, **kwargs):
+def _plot_categorical_feature2(feature_1, feature_2, data, ax, **kwargs):
     """Plot when the second feature is categorical-like."""
     dup_df = pd.DataFrame()
     dup_df[feature_2] = _copy_series_or_keep_top_10(data[feature_2])
@@ -220,21 +220,21 @@ def plot_categorical_feature2(feature_1, feature_2, data, ax, **kwargs):
     chart.set_xticklabels(chart.get_xticklabels(), rotation=45, ha='right')
 
 
-def plot_datetime_feature2(feature_1, feature_2, data, ax, **kwargs):
+def _plot_datetime_feature2(feature_1, feature_2, data, ax, **kwargs):
     """Plot when the second feature is datetime."""
     ax.plot(data[feature_2], data[feature_1], **kwargs)
     ax.set_xlabel(feature_2)
     ax.set_ylabel(feature_1)
 
 
-def plot_numeric_features(feature_1, feature_2, data, ax, **kwargs):
+def _plot_numeric_features(feature_1, feature_2, data, ax, **kwargs):
     """Plot when both features are numeric."""
     ax.scatter(data[feature_1], data[feature_2], **kwargs)
     ax.set_xlabel(feature_1)
     ax.set_ylabel(feature_2)
 
 
-def plot_categorical_vs_categorical(feature_1, feature_2, dup_df, data, ax, **kwargs):
+def _plot_categorical_vs_categorical(feature_1, feature_2, dup_df, data, ax, **kwargs):
     """Plot when both features are categorical-like."""
     dup_df[feature_2] = _copy_series_or_keep_top_10(data[feature_2])
     group_feature_1 = dup_df[feature_1].unique().tolist()
@@ -244,8 +244,8 @@ def plot_categorical_vs_categorical(feature_1, feature_2, dup_df, data, ax, **kw
     ax.legend(title=feature_2)
 
 
-def plot_categorical_vs_datetime(feature_1, feature_2, dup_df, data, ax, **kwargs):
-    """Plot when the first feature is categorical-like and the second is datetime."""
+def _plot_categorical_vs_datetime(feature_1, feature_2, dup_df, data, ax, **kwargs):
+    """Plot when the first feature is categorical-like, and the second is datetime."""
     dup_df[feature_2] = data[feature_2].apply(dates.date2num)
     chart = sns.violinplot(x=feature_2, y=feature_1, data=dup_df, ax=ax)
     ticks_loc = chart.get_xticks()
@@ -254,7 +254,7 @@ def plot_categorical_vs_datetime(feature_1, feature_2, dup_df, data, ax, **kwarg
     ax.xaxis.set_major_formatter(_convert_numbers_to_dates)
 
 
-def plot_categorical_vs_numeric(feature_1, feature_2, dup_df, data, ax, **kwargs):
+def _plot_categorical_vs_numeric(feature_1, feature_2, dup_df, data, ax, **kwargs):
     """Plot when the first feature is categorical-like and the second is numeric."""
     dup_df[feature_2] = data[feature_2]
     chart = sns.boxplot(x=feature_1, y=feature_2, data=dup_df, ax=ax, **kwargs)
@@ -263,7 +263,7 @@ def plot_categorical_vs_numeric(feature_1, feature_2, dup_df, data, ax, **kwargs
     chart.set_xticklabels(chart.get_xticklabels(), rotation=45, ha='right')
 
 
-def plot_datetime_vs_categorical(feature_1, feature_2, data, ax, **kwargs):
+def _plot_datetime_vs_categorical(feature_1, feature_2, data, ax, **kwargs):
     """Plot when the first feature is datetime and the second is categorical-like."""
     dup_df = pd.DataFrame()
     dup_df[feature_1] = data[feature_1].apply(dates.date2num)
@@ -318,7 +318,7 @@ def extract_statistics_dataframe_per_label(
             - 99_percentile: 99th percentile
             - max: Maximum value
 
-    :raises KeyError: If feature_name or label_name not found in DataFrame
+    :raises KeyError: If feature_name or label_name is not found in DataFrame
     :raises TypeError: If feature_name column is not numeric
     """
     if feature_name not in df.columns:

--- a/ds_utils/preprocess.py
+++ b/ds_utils/preprocess.py
@@ -14,7 +14,7 @@ from ds_utils.math_utils import safe_percentile
 
 
 def visualize_feature(
-        series: pd.Series, remove_na: bool = False, *, ax: Optional[axes.Axes] = None, **kwargs
+    series: pd.Series, remove_na: bool = False, *, ax: Optional[axes.Axes] = None, **kwargs
 ) -> axes.Axes:
     """Visualize a feature series.
 
@@ -58,7 +58,7 @@ def visualize_feature(
 
 
 def get_correlated_features(
-        correlation_matrix: pd.DataFrame, features: List[str], target_feature: str, threshold: float = 0.95
+    correlation_matrix: pd.DataFrame, features: List[str], target_feature: str, threshold: float = 0.95
 ) -> pd.DataFrame:
     """Calculate features correlated above a threshold with target correlations.
 
@@ -108,11 +108,11 @@ def visualize_correlations(correlation_matrix: pd.DataFrame, *, ax: Optional[axe
 
 
 def plot_correlation_dendrogram(
-        correlation_matrix: pd.DataFrame,
-        cluster_distance_method: Union[str, Callable] = "average",
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs,
+    correlation_matrix: pd.DataFrame,
+    cluster_distance_method: Union[str, Callable] = "average",
+    *,
+    ax: Optional[axes.Axes] = None,
+    **kwargs,
 ) -> axes.Axes:
     """Plot a dendrogram of the correlation matrix, showing hierarchically the most correlated variables.
 
@@ -136,7 +136,7 @@ def plot_correlation_dendrogram(
 
 
 def plot_features_interaction(
-        data: pd.DataFrame, feature_1: str, feature_2: str, *, ax: Optional[axes.Axes] = None, **kwargs
+    data: pd.DataFrame, feature_1: str, feature_2: str, *, ax: Optional[axes.Axes] = None, **kwargs
 ) -> axes.Axes:
     """Plot the joint distribution between two features.
 
@@ -170,9 +170,9 @@ def plot_features_interaction(
 def _is_categorical_like(dtype):
     """Check if the dtype is categorical-like (categorical, boolean, or object)."""
     return (
-            isinstance(dtype, pd.CategoricalDtype)
-            or pd.api.types.is_bool_dtype(dtype)
-            or pd.api.types.is_object_dtype(dtype)
+        isinstance(dtype, pd.CategoricalDtype)
+        or pd.api.types.is_bool_dtype(dtype)
+        or pd.api.types.is_object_dtype(dtype)
     )
 
 

--- a/ds_utils/preprocess.py
+++ b/ds_utils/preprocess.py
@@ -169,7 +169,7 @@ def plot_features_interaction(
 
 def _is_categorical_like(dtype):
     """Check if the dtype is categorical-like (categorical, boolean, or object)."""
-    return isinstance(dtype, pd.CategoricalDtype) or dtype is bool or dtype is object
+    return isinstance(dtype, pd.CategoricalDtype) or isinstance(dtype, bool) or dtype == object
 
 
 def _plot_categorical_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs):

--- a/ds_utils/preprocess.py
+++ b/ds_utils/preprocess.py
@@ -169,7 +169,9 @@ def plot_features_interaction(
 
 def _is_categorical_like(dtype):
     """Check if the dtype is categorical-like (categorical, boolean, or object)."""
-    return isinstance(dtype, pd.CategoricalDtype) or dtype == bool or dtype == object
+    return (isinstance(dtype, pd.CategoricalDtype) or
+            pd.api.types.is_bool_dtype(dtype) or
+            pd.api.types.is_object_dtype(dtype))
 
 
 def _plot_categorical_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs):

--- a/ds_utils/preprocess.py
+++ b/ds_utils/preprocess.py
@@ -1,3 +1,5 @@
+"""Data preprocessing utilities."""
+
 import warnings
 from typing import Optional, Union, Callable, List
 
@@ -12,14 +14,9 @@ from ds_utils.math_utils import safe_percentile
 
 
 def visualize_feature(
-        series: pd.Series,
-        remove_na: bool = False,
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs
+        series: pd.Series, remove_na: bool = False, *, ax: Optional[axes.Axes] = None, **kwargs
 ) -> axes.Axes:
-    """
-    Visualize a feature series:
+    """Visualize a feature series.
 
     * For float features, plot a distribution plot.
     * For datetime features, plot a line plot of progression over time.
@@ -52,7 +49,7 @@ def visualize_feature(
 
     ticks_loc = ax.get_xticks()
     ax.xaxis.set_major_locator(ticker.FixedLocator(ticks_loc))
-    ax.set_xticklabels(labels, rotation=45, ha='right')
+    ax.set_xticklabels(labels, rotation=45, ha="right")
 
     if pd.api.types.is_datetime64_any_dtype(feature_series):
         ax.xaxis.set_major_formatter(_convert_numbers_to_dates)
@@ -61,12 +58,10 @@ def visualize_feature(
 
 
 def get_correlated_features(
-        correlation_matrix: pd.DataFrame,
-        features: List[str],
-        target_feature: str,
-        threshold: float = 0.95
+        correlation_matrix: pd.DataFrame, features: List[str], target_feature: str, threshold: float = 0.95
 ) -> pd.DataFrame:
-    """
+    """Calculate features correlated above a threshold with target correlations.
+
     Calculate features correlated above a threshold and extract a DataFrame with correlations and correlation
     to the target feature.
 
@@ -85,7 +80,8 @@ def get_correlated_features(
     if corr_matrix.empty:
         warnings.warn(f"Correlation threshold {threshold} was too high. An empty frame was returned", UserWarning)
         return pd.DataFrame(
-            columns=['level_0', 'level_1', 'level_0_level_1_corr', 'level_0_target_corr', 'level_1_target_corr'])
+            columns=["level_0", "level_1", "level_0_level_1_corr", "level_0_target_corr", "level_1_target_corr"]
+        )
 
     corr_matrix["level_0_target_corr"] = target_corr[corr_matrix["level_0"]].values
     corr_matrix["level_1_target_corr"] = target_corr[corr_matrix["level_1"]].values
@@ -93,15 +89,10 @@ def get_correlated_features(
     return corr_matrix
 
 
-def visualize_correlations(
-        correlation_matrix: pd.DataFrame,
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs
-) -> axes.Axes:
-    """
-    Compute and visualize pairwise correlations of columns, excluding NA/null values.
-    `Original Seaborn code <https://seaborn.pydata.org/examples/many_pairwise_correlations.html>`_
+def visualize_correlations(correlation_matrix: pd.DataFrame, *, ax: Optional[axes.Axes] = None, **kwargs) -> axes.Axes:
+    """Compute and visualize pairwise correlations of columns, excluding NA/null values.
+
+    `Original Seaborn code <https://seaborn.pydata.org/examples/many_pairwise_correlations.html>`_.
 
     :param correlation_matrix: The correlation matrix.
     :param ax: Axes in which to draw the plot. If None, use the currently active Axes.
@@ -121,11 +112,11 @@ def plot_correlation_dendrogram(
         cluster_distance_method: Union[str, Callable] = "average",
         *,
         ax: Optional[axes.Axes] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
-    """
-    Plot a dendrogram of the correlation matrix, showing hierarchically the most correlated variables.
-    `Original XAI code <https://github.com/EthicalML/XAI>`_
+    """Plot a dendrogram of the correlation matrix, showing hierarchically the most correlated variables.
+
+    `Original XAI code <https://github.com/EthicalML/XAI>`_.
 
     :param correlation_matrix: The correlation matrix.
     :param cluster_distance_method: Method for calculating the distance between newly formed clusters.
@@ -145,14 +136,9 @@ def plot_correlation_dendrogram(
 
 
 def plot_features_interaction(
-        data: pd.DataFrame,
-        feature_1: str,
-        feature_2: str,
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs) -> axes.Axes:
-    """
-    Plot the joint distribution between two features.
+        data: pd.DataFrame, feature_1: str, feature_2: str, *, ax: Optional[axes.Axes] = None, **kwargs
+) -> axes.Axes:
+    """Plot the joint distribution between two features.
 
     :param data: The input DataFrame, where each feature is a column.
     :param feature_1: Name of the first feature.
@@ -183,7 +169,7 @@ def plot_features_interaction(
 
 def _is_categorical_like(dtype):
     """Check if the dtype is categorical-like (categorical, boolean, or object)."""
-    return isinstance(dtype, pd.CategoricalDtype) or dtype == bool or dtype == object
+    return isinstance(dtype, pd.CategoricalDtype) or dtype is bool or dtype is object
 
 
 def _plot_categorical_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs):
@@ -217,7 +203,7 @@ def _plot_categorical_feature2(feature_1, feature_2, data, ax, **kwargs):
     chart = sns.boxplot(x=feature_2, y=feature_1, data=dup_df, ax=ax, **kwargs)
     ticks_loc = chart.get_xticks()  # Get the tick positions
     chart.xaxis.set_major_locator(ticker.FixedLocator(ticks_loc))  # Explicitly set the tick positions
-    chart.set_xticklabels(chart.get_xticklabels(), rotation=45, ha='right')
+    chart.set_xticklabels(chart.get_xticklabels(), rotation=45, ha="right")
 
 
 def _plot_datetime_feature2(feature_1, feature_2, data, ax, **kwargs):
@@ -238,8 +224,11 @@ def _plot_categorical_vs_categorical(feature_1, feature_2, dup_df, data, ax, **k
     """Plot when both features are categorical-like."""
     dup_df[feature_2] = _copy_series_or_keep_top_10(data[feature_2])
     group_feature_1 = dup_df[feature_1].unique().tolist()
-    ax.hist([dup_df.loc[dup_df[feature_1] == value, feature_2] for value in group_feature_1],
-            label=group_feature_1, **kwargs)
+    ax.hist(
+        [dup_df.loc[dup_df[feature_1] == value, feature_2] for value in group_feature_1],
+        label=group_feature_1,
+        **kwargs,
+    )
     ax.set_xlabel(feature_1)
     ax.legend(title=feature_2)
 
@@ -250,7 +239,7 @@ def _plot_categorical_vs_datetime(feature_1, feature_2, dup_df, data, ax, **kwar
     chart = sns.violinplot(x=feature_2, y=feature_1, data=dup_df, ax=ax)
     ticks_loc = chart.get_xticks()
     chart.xaxis.set_major_locator(ticker.FixedLocator(ticks_loc))
-    chart.set_xticklabels(chart.get_xticklabels(), rotation=45, ha='right')
+    chart.set_xticklabels(chart.get_xticklabels(), rotation=45, ha="right")
     ax.xaxis.set_major_formatter(_convert_numbers_to_dates)
 
 
@@ -260,7 +249,7 @@ def _plot_categorical_vs_numeric(feature_1, feature_2, dup_df, data, ax, **kwarg
     chart = sns.boxplot(x=feature_1, y=feature_2, data=dup_df, ax=ax, **kwargs)
     ticks_loc = chart.get_xticks()  # Get the tick positions
     chart.xaxis.set_major_locator(ticker.FixedLocator(ticks_loc))  # Explicitly set the tick positions
-    chart.set_xticklabels(chart.get_xticklabels(), rotation=45, ha='right')
+    chart.set_xticklabels(chart.get_xticklabels(), rotation=45, ha="right")
 
 
 def _plot_datetime_vs_categorical(feature_1, feature_2, data, ax, **kwargs):
@@ -271,7 +260,7 @@ def _plot_datetime_vs_categorical(feature_1, feature_2, data, ax, **kwargs):
     chart = sns.violinplot(x=feature_1, y=feature_2, data=dup_df, ax=ax)
     ticks_loc = chart.get_xticks()
     chart.xaxis.set_major_locator(ticker.FixedLocator(ticks_loc))
-    chart.set_xticklabels(chart.get_xticklabels(), rotation=45, ha='right')
+    chart.set_xticklabels(chart.get_xticklabels(), rotation=45, ha="right")
     ax.xaxis.set_major_formatter(_convert_numbers_to_dates)
 
 
@@ -286,16 +275,11 @@ def _copy_series_or_keep_top_10(series: pd.Series) -> pd.Series:
 
 @plt.FuncFormatter
 def _convert_numbers_to_dates(x, pos):
-    return dates.num2date(x).strftime('%Y-%m-%d %H:%M')
+    return dates.num2date(x).strftime("%Y-%m-%d %H:%M")
 
 
-def extract_statistics_dataframe_per_label(
-        df: pd.DataFrame,
-        feature_name: str,
-        label_name: str
-) -> pd.DataFrame:
-    """
-    Calculate comprehensive statistical metrics for a specified feature grouped by label.
+def extract_statistics_dataframe_per_label(df: pd.DataFrame, feature_name: str, label_name: str) -> pd.DataFrame:
+    """Calculate comprehensive statistical metrics for a specified feature grouped by label.
 
     This method computes various statistical measures for a given numerical feature, broken down by unique
     values in the specified label column. The statistics include count, null count,
@@ -348,20 +332,19 @@ def extract_statistics_dataframe_per_label(
     def percentile_99(x):
         return safe_percentile(x, 99)
 
-    return df.groupby(
-        [label_name],
-        observed=True
-    )[feature_name].agg([
-        ("count", "count"),
-        ("null_count", lambda x: x.isnull().sum()),
-        ("mean", "mean"),
-        ("min", "min"),
-        ("1_percentile", percentile_1),
-        ("5_percentile", percentile_5),
-        ("25_percentile", percentile_25),
-        ("median", "median"),
-        ("75_percentile", percentile_75),
-        ("95_percentile", percentile_95),
-        ("99_percentile", percentile_99),
-        ("max", "max")
-    ])
+    return df.groupby([label_name], observed=True)[feature_name].agg(
+        [
+            ("count", "count"),
+            ("null_count", lambda x: x.isnull().sum()),
+            ("mean", "mean"),
+            ("min", "min"),
+            ("1_percentile", percentile_1),
+            ("5_percentile", percentile_5),
+            ("25_percentile", percentile_25),
+            ("median", "median"),
+            ("75_percentile", percentile_75),
+            ("95_percentile", percentile_95),
+            ("99_percentile", percentile_99),
+            ("max", "max"),
+        ]
+    )

--- a/ds_utils/preprocess.py
+++ b/ds_utils/preprocess.py
@@ -169,9 +169,11 @@ def plot_features_interaction(
 
 def _is_categorical_like(dtype):
     """Check if the dtype is categorical-like (categorical, boolean, or object)."""
-    return (isinstance(dtype, pd.CategoricalDtype) or
-            pd.api.types.is_bool_dtype(dtype) or
-            pd.api.types.is_object_dtype(dtype))
+    return (
+            isinstance(dtype, pd.CategoricalDtype)
+            or pd.api.types.is_bool_dtype(dtype)
+            or pd.api.types.is_object_dtype(dtype)
+    )
 
 
 def _plot_categorical_feature1(feature_1, feature_2, data, dtype2, ax, **kwargs):

--- a/ds_utils/strings.py
+++ b/ds_utils/strings.py
@@ -1,3 +1,5 @@
+"""String manipulation utilities for data science tasks."""
+
 import re
 from typing import List, Tuple, Optional, Callable, Union
 
@@ -21,10 +23,9 @@ def append_tags_to_frame(
         max_features: Optional[int] = 500,
         min_df: Union[int, float] = 1,
         lowercase: bool = False,
-        tokenizer: Optional[Callable[[str], List[str]]] = _tokenize
+        tokenizer: Optional[Callable[[str], List[str]]] = _tokenize,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
-    """
-    Extract tags from a given field and append them to the dataframe.
+    """Extract tags from a given field and append them to the dataframe.
 
     :param X_train: Pandas DataFrame with the train features.
     :param X_test: Pandas DataFrame with the test features.
@@ -33,7 +34,7 @@ def append_tags_to_frame(
     :param max_features: Maximum number of tag names to consider. Default is 500. This helps limit the number of
                          new columns created, especially useful for datasets with a large number of unique tags.
     :param min_df: When building the tag name set, ignore tags with a document frequency strictly
-                   lower than the given threshold. If float, the parameter represents a proportion
+                   lower than the given threshold. If min_df is a float, the parameter represents a proportion
                    of documents. If integer, it represents absolute counts. Default is 1. This helps filter out
                    rare tags.
     :param lowercase: Convert all characters to lowercase before tokenizing the tag names. Default is False. Set to
@@ -42,10 +43,17 @@ def append_tags_to_frame(
                       preprocessing and n-grams generation steps. Default splits by ",", and
                       retains alphanumeric characters with special characters "_", "$", and "-".
     :return: The train and test DataFrames with tags appended.
-    :raise KeyError: if the one of the frames is missing columns.
+    :raise KeyError: if one of the frames is missing columns.
     """
-    vectorizer = CountVectorizer(binary=True, tokenizer=tokenizer, encoding="utf-8", lowercase=lowercase,
-                                 min_df=min_df, max_features=max_features, token_pattern=None)
+    vectorizer = CountVectorizer(
+        binary=True,
+        tokenizer=tokenizer,
+        encoding="utf-8",
+        lowercase=lowercase,
+        min_df=min_df,
+        max_features=max_features,
+        token_pattern=None,
+    )
 
     if X_train.empty:
         return pd.DataFrame(), pd.DataFrame()
@@ -64,27 +72,26 @@ def append_tags_to_frame(
     x_train_reduced = X_train.drop(columns=[field_name])
     x_test_reduced = X_test.drop(columns=[field_name])
 
-    return (pd.merge(x_train_reduced, x_train_tags, left_index=True, right_index=True, how="left"),
-            pd.merge(x_test_reduced, x_test_tags, left_index=True, right_index=True, how="left"))
+    return (
+        pd.merge(x_train_reduced, x_train_tags, left_index=True, right_index=True, how="left"),
+        pd.merge(x_test_reduced, x_test_tags, left_index=True, right_index=True, how="left"),
+    )
 
 
 def extract_significant_terms_from_subset(
         data_frame: pd.DataFrame,
         subset_data_frame: pd.DataFrame,
         field_name: str,
-        vectorizer: CountVectorizer = CountVectorizer(encoding="utf-8",
-                                                      lowercase=True,
-                                                      max_features=500)
+        vectorizer: CountVectorizer = CountVectorizer(encoding="utf-8", lowercase=True, max_features=500),
 ) -> pd.Series:
-    """
-    Return interesting or unusual occurrences of terms in a subset.
+    """Return interesting or unusual occurrences of terms in a subset.
 
     Based on the elasticsearch significant_text aggregation:
     https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-significantterms-aggregation.html#_scripted
 
     :param data_frame: The full dataset.
     :param subset_data_frame: The subset partition data over which the scoring will be calculated.
-                              Can be filtered by feature or other boolean criteria.
+                              It can be filtered by feature or other boolean criteria.
     :param field_name: The feature to parse.
     :param vectorizer: Text count vectorizer which converts a collection of text to a matrix of token counts.
                        See more info here:

--- a/ds_utils/strings.py
+++ b/ds_utils/strings.py
@@ -16,14 +16,14 @@ def _tokenize(text_tags: str) -> List[str]:
 
 
 def append_tags_to_frame(
-        X_train: pd.DataFrame,
-        X_test: pd.DataFrame,
-        field_name: str,
-        prefix: str = "",
-        max_features: Optional[int] = 500,
-        min_df: Union[int, float] = 1,
-        lowercase: bool = False,
-        tokenizer: Optional[Callable[[str], List[str]]] = _tokenize,
+    X_train: pd.DataFrame,
+    X_test: pd.DataFrame,
+    field_name: str,
+    prefix: str = "",
+    max_features: Optional[int] = 500,
+    min_df: Union[int, float] = 1,
+    lowercase: bool = False,
+    tokenizer: Optional[Callable[[str], List[str]]] = _tokenize,
 ) -> Tuple[pd.DataFrame, pd.DataFrame]:
     """Extract tags from a given field and append them to the dataframe.
 
@@ -79,10 +79,10 @@ def append_tags_to_frame(
 
 
 def extract_significant_terms_from_subset(
-        data_frame: pd.DataFrame,
-        subset_data_frame: pd.DataFrame,
-        field_name: str,
-        vectorizer: CountVectorizer = CountVectorizer(encoding="utf-8", lowercase=True, max_features=500),
+    data_frame: pd.DataFrame,
+    subset_data_frame: pd.DataFrame,
+    field_name: str,
+    vectorizer: CountVectorizer = CountVectorizer(encoding="utf-8", lowercase=True, max_features=500),
 ) -> pd.Series:
     """Return interesting or unusual occurrences of terms in a subset.
 

--- a/ds_utils/unsupervised.py
+++ b/ds_utils/unsupervised.py
@@ -1,3 +1,5 @@
+"""Unsupervised learning utilities for clustering visualization and analysis."""
+
 from typing import Optional, Callable, Dict, Any
 
 import numpy as np
@@ -12,14 +14,8 @@ def _extract_cardinality(labels):
     return cardinality
 
 
-def plot_cluster_cardinality(
-        labels: np.ndarray,
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs
-) -> axes.Axes:
-    """
-    Plot the number of points per cluster as a bar chart.
+def plot_cluster_cardinality(labels: np.ndarray, *, ax: Optional[axes.Axes] = None, **kwargs) -> axes.Axes:
+    """Plot the number of points per cluster as a bar chart.
 
     Cluster cardinality is the number of examples per cluster.
 
@@ -27,7 +23,7 @@ def plot_cluster_cardinality(
     :param ax: Axes object to draw the plot onto; if None, uses the current Axes.
     :param kwargs: Additional keyword arguments passed to `matplotlib.axes.Axes.bar()`.
     :return: The Axes object with the plot drawn onto it.
-    :raises ValueError: If labels is empty.
+    :raises ValueError: If labels are empty.
     """
     if ax is None:
         _, ax = plt.subplots()
@@ -44,12 +40,7 @@ def plot_cluster_cardinality(
     return ax
 
 
-def _extract_magnitude(
-        X,
-        labels,
-        cluster_centers,
-        distance_function
-):
+def _extract_magnitude(X, labels, cluster_centers, distance_function):
     data = pd.DataFrame({"point": list(X), "label": labels})
     data["center"] = data["label"].apply(lambda label: cluster_centers[label])
     data["distance"] = data.apply(lambda row: distance_function(row["point"], row["center"]), axis=1)
@@ -64,10 +55,9 @@ def plot_cluster_magnitude(
         distance_function: Callable[[np.ndarray, np.ndarray], float],
         *,
         ax: Optional[axes.Axes] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
-    """
-    Plot the Total Point-to-Centroid Distance per cluster as a bar chart.
+    """Plot the Total Point-to-Centroid Distance per cluster as a bar chart.
 
     Cluster magnitude is the sum of distances from all examples to the centroid of the cluster.
 
@@ -81,7 +71,6 @@ def plot_cluster_magnitude(
     :return: The Axes object with the plot drawn onto it.
     :raises ValueError: If input arrays have inconsistent shapes or if distance_function is invalid.
     """
-
     if ax is None:
         _, ax = plt.subplots()
 
@@ -111,10 +100,9 @@ def plot_magnitude_vs_cardinality(
         distance_function: Callable[[np.ndarray, np.ndarray], float],
         *,
         ax: Optional[axes.Axes] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
-    """
-    Plot magnitude against cardinality as a scatter plot to find anomalous clusters.
+    """Plot magnitude against cardinality as a scatter plot to find anomalous clusters.
 
     Higher cluster cardinality tends to result in a higher cluster magnitude. Clusters are considered
     anomalous when cardinality doesn't correlate with magnitude relative to the other clusters.
@@ -152,7 +140,7 @@ def plot_magnitude_vs_cardinality(
     for index, point in merged.iterrows():
         ax.annotate(str(index), (point["Cardinality"], point["Magnitude"]))
 
-    line = lines.Line2D([0, 1], [0, 1], transform=ax.transAxes, color='r', linestyle='--')
+    line = lines.Line2D([0, 1], [0, 1], transform=ax.transAxes, color="r", linestyle="--")
     ax.add_line(line)
 
     ax.set_xlabel("Cardinality")
@@ -169,24 +157,23 @@ def plot_loss_vs_cluster_number(
         *,
         algorithm_parameters: Dict[str, Any] = None,
         ax: Optional[axes.Axes] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
+    """Plot the Total magnitude (sum of distances) as loss against the number of clusters.
+
+    This method runs the KMeans algorithm with increasing cluster numbers and plots the resulting loss.
+
+    :param X: Training instances.
+    :param k_min: The minimum cluster number.
+    :param k_max: The maximum cluster number.
+    :param distance_function: Function to calculate the distance between an instance and its cluster center.
+           It should take two ndarrays (instance and center) and return a float.
+    :param algorithm_parameters: Parameters to use for the KMeans algorithm. If None, default parameters will be used.
+    :param ax: Axes object to draw the plot onto; if None, uses the current Axes.
+    :param kwargs: Additional keyword arguments passed to `matplotlib.axes.Axes.scatter()`.
+    :return: The Axes object with the plot drawn onto it.
+    :raises ValueError: If k_min > k_max or if invalid parameters are provided.
     """
-        Plot the Total magnitude (sum of distances) as loss against the number of clusters.
-
-        This method runs the KMeans algorithm with increasing cluster numbers and plots the resulting loss.
-
-        :param X: Training instances.
-        :param k_min: The minimum cluster number.
-        :param k_max: The maximum cluster number.
-        :param distance_function: Function to calculate the distance between an instance and its cluster center.
-               It should take two ndarrays (instance and center) and return a float.
-        :param algorithm_parameters: Parameters to use for the KMeans algorithm. If None, default parameters will be used.
-        :param ax: Axes object to draw the plot onto; if None, uses the current Axes.
-        :param kwargs: Additional keyword arguments passed to `matplotlib.axes.Axes.scatter()`.
-        :return: The Axes object with the plot drawn onto it.
-        :raises ValueError: If k_min > k_max or if invalid parameters are provided.
-        """
     if ax is None:
         _, ax = plt.subplots()
 
@@ -208,7 +195,8 @@ def plot_loss_vs_cluster_number(
             estimator = KMeans(n_clusters=k, **algorithm_parameters)
             estimator.fit(X)
             magnitude = pd.DataFrame(
-                _extract_magnitude(X, estimator.labels_, estimator.cluster_centers_, distance_function))
+                _extract_magnitude(X, estimator.labels_, estimator.cluster_centers_, distance_function)
+            )
             result.append({"k": k, "magnitude": magnitude["distance"].sum()})
         except Exception as e:
             print(f"Error occurred for k={k}: {str(e)}")

--- a/ds_utils/unsupervised.py
+++ b/ds_utils/unsupervised.py
@@ -49,13 +49,13 @@ def _extract_magnitude(X, labels, cluster_centers, distance_function):
 
 
 def plot_cluster_magnitude(
-        X: np.ndarray,
-        labels: np.ndarray,
-        cluster_centers: np.ndarray,
-        distance_function: Callable[[np.ndarray, np.ndarray], float],
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs,
+    X: np.ndarray,
+    labels: np.ndarray,
+    cluster_centers: np.ndarray,
+    distance_function: Callable[[np.ndarray, np.ndarray], float],
+    *,
+    ax: Optional[axes.Axes] = None,
+    **kwargs,
 ) -> axes.Axes:
     """Plot the Total Point-to-Centroid Distance per cluster as a bar chart.
 
@@ -94,13 +94,13 @@ def plot_cluster_magnitude(
 
 
 def plot_magnitude_vs_cardinality(
-        X: np.ndarray,
-        labels: np.ndarray,
-        cluster_centers: np.ndarray,
-        distance_function: Callable[[np.ndarray, np.ndarray], float],
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs,
+    X: np.ndarray,
+    labels: np.ndarray,
+    cluster_centers: np.ndarray,
+    distance_function: Callable[[np.ndarray, np.ndarray], float],
+    *,
+    ax: Optional[axes.Axes] = None,
+    **kwargs,
 ) -> axes.Axes:
     """Plot magnitude against cardinality as a scatter plot to find anomalous clusters.
 
@@ -150,14 +150,14 @@ def plot_magnitude_vs_cardinality(
 
 
 def plot_loss_vs_cluster_number(
-        X: np.ndarray,
-        k_min: int,
-        k_max: int,
-        distance_function: Callable[[np.ndarray, np.ndarray], float],
-        *,
-        algorithm_parameters: Dict[str, Any] = None,
-        ax: Optional[axes.Axes] = None,
-        **kwargs,
+    X: np.ndarray,
+    k_min: int,
+    k_max: int,
+    distance_function: Callable[[np.ndarray, np.ndarray], float],
+    *,
+    algorithm_parameters: Dict[str, Any] = None,
+    ax: Optional[axes.Axes] = None,
+    **kwargs,
 ) -> axes.Axes:
     """Plot the Total magnitude (sum of distances) as loss against the number of clusters.
 

--- a/ds_utils/xai.py
+++ b/ds_utils/xai.py
@@ -1,3 +1,5 @@
+"""Explainable AI (XAI) utilities, focusing on model interpretation."""
+
 import os
 import warnings
 from io import StringIO, BytesIO
@@ -17,7 +19,7 @@ def _recurse(
         feature_name: List[str],
         class_names: Optional[List[str]],
         output: StringIO,
-        indent_char: str
+        indent_char: str,
 ):
     indent = indent_char * depth
     if tree.feature[node] != sklearn_tree.TREE_UNDEFINED:
@@ -34,9 +36,8 @@ def _recurse(
         if np.max(prob_array) >= 1:
             prob_array = values / (np.sum(values) + 1)
         class_name = class_names[index] if class_names else f"class_{index}"
-        output.write(
-            f"{indent}# return class {class_name} with probability {prob_array[index]:.4f}{os.linesep}")
-        output.write(f"{indent}return (\"{class_name}\", {prob_array[index]:.4f}){os.linesep}")
+        output.write(f"{indent}# return class {class_name} with probability {prob_array[index]:.4f}{os.linesep}")
+        output.write(f'{indent}return ("{class_name}", {prob_array[index]:.4f}){os.linesep}')
 
 
 def generate_decision_paths(
@@ -44,18 +45,19 @@ def generate_decision_paths(
         feature_names: Optional[List[str]] = None,
         class_names: Optional[List[str]] = None,
         tree_name: Optional[str] = None,
-        indent_char: str = "\t"
+        indent_char: str = "\t",
 ) -> str:
-    """
-    Generate decision rules (or 'decision paths') as text (valid Python syntax) from a decision tree.
-    `Original code <https://stackoverflow.com/questions/20224526/how-to-extract-the-decision-rules-from-scikit-learn-decision-tree>`_
+    """Generate decision rules as text from a decision tree.
 
-    :param classifier: Decision tree classifier
-    :param feature_names: List of feature names
-    :param class_names: List of class names or labels
-    :param tree_name: Name of the tree (function signature)
-    :param indent_char: Character used for indentation
-    :return: Textual representation of the decision paths of the tree
+    Generate decision rules (or 'decision paths') as text (valid Python syntax) from a decision tree.
+    `Original code <https://stackoverflow.com/questions/20224526/how-to-extract-the-decision-rules-from-scikit-learn-decision-tree>`_.
+
+    :param classifier: Decision tree classifier.
+    :param feature_names: List of feature names.
+    :param class_names: List of class names or labels.
+    :param tree_name: Name of the tree (function signature).
+    :param indent_char: Character used for indentation.
+    :return: Textual representation of the decision paths in the tree.
     """
     warnings.warn("This module is deprecated. Use sklearn.tree.export_text instead", DeprecationWarning, stacklevel=2)
 
@@ -65,7 +67,7 @@ def generate_decision_paths(
     tree_name = tree_name or "tree"
 
     output = StringIO()
-    signature_vars = list(dict.fromkeys(f for f in required_features if f != 'undefined!'))
+    signature_vars = list(dict.fromkeys(f for f in required_features if f != "undefined!"))
     output.write(f"def {tree_name}({', '.join(signature_vars)}):{os.linesep}")
 
     _recurse(0, 1, tree, required_features, class_names, output, indent_char)
@@ -81,38 +83,38 @@ def draw_tree(
         class_names: Optional[List[str]] = None,
         *,
         ax: Optional[axes.Axes] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
-    """
-    Plot a graph of the decision tree for easy interpretation.
+    """Plot a graph of the decision tree for easy interpretation.
 
-    :param tree: Decision tree
-    :param feature_names: List of feature names
-    :param class_names: List of class names or labels
-    :param ax: Axes object to draw the plot onto, otherwise uses the current Axes
-    :param kwargs: Additional keyword arguments passed to matplotlib.axes.Axes.imshow()
-    :return: Axes object with the plot drawn onto it
+    :param tree: Decision tree.
+    :param feature_names: List of feature names.
+    :param class_names: List of class names or labels.
+    :param ax: Axes object to draw the plot onto, otherwise uses the current Axes.
+    :param kwargs: Additional keyword arguments passed to `matplotlib.axes.Axes.imshow()`.
+    :return: Axes object with the plot drawn onto it.
     """
     warnings.warn("This module is deprecated. Use sklearn.tree.plot_tree instead", DeprecationWarning, stacklevel=2)
-    dot_data = export_graphviz(tree, feature_names=feature_names, out_file=None, filled=True, rounded=True,
-                               special_characters=True, class_names=class_names)
+    dot_data = export_graphviz(
+        tree,
+        feature_names=feature_names,
+        out_file=None,
+        filled=True,
+        rounded=True,
+        special_characters=True,
+        class_names=class_names,
+    )
     return draw_dot_data(dot_data, ax=ax, **kwargs)
 
 
-def draw_dot_data(
-        dot_data: str,
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs
-) -> axes.Axes:
-    """
-    Plot a graph from Graphviz's Dot language string.
+def draw_dot_data(dot_data: str, *, ax: Optional[axes.Axes] = None, **kwargs) -> axes.Axes:
+    """Plot a graph from Graphviz's Dot language string.
 
     :param dot_data: Graphviz's Dot language string. Use sklearn.tree.export_graphviz to generate the dot data string.
-    :param ax: Axes object to draw the plot onto, otherwise uses the current Axes
-    :param kwargs: Additional keyword arguments passed to matplotlib.axes.Axes.imshow()
-    :return: Axes object with the plot drawn onto it
-    :raises ValueError: If the dot_data is empty or invalid
+    :param ax: Axes object to draw the plot onto, otherwise uses the current Axes.
+    :param kwargs: Additional keyword arguments passed to `matplotlib.axes.Axes.imshow()`.
+    :return: Axes object with the plot drawn onto it.
+    :raises ValueError: If the dot_data is empty or invalid.
     """
     if not dot_data:
         raise ValueError("dot_data must not be empty")
@@ -139,17 +141,16 @@ def plot_features_importance(
         feature_importance: Union[np.ndarray, List[float]],
         *,
         ax: Optional[axes.Axes] = None,
-        **kwargs
+        **kwargs,
 ) -> axes.Axes:
-    """
-    Plot feature importance as a bar chart.
+    """Plot feature importance as a bar chart.
 
-    :param feature_names: Numpy array or list of feature names of shape (n_features,)
-    :param feature_importance:  Numpy array or list of feature importance values of shape (n_features,)
-    :param ax: Axes object to draw the plot onto, otherwise uses the current Axes
-    :param kwargs: Additional keyword arguments passed to matplotlib.axes.Axes.bar()
-    :return: Axes object with the plot drawn onto it
-    :raises ValueError: If feature_names and feature_importance have different lengths or invalid input
+    :param feature_names: Numpy array or list of feature names with shape (n_features,).
+    :param feature_importance:  Numpy array or list of feature importance values with shape (n_features,).
+    :param ax: Axes object to draw the plot onto, otherwise uses the current Axes.
+    :param kwargs: Additional keyword arguments passed to `matplotlib.axes.Axes.bar()`.
+    :return: Axes object with the plot drawn onto it.
+    :raises ValueError: If feature_names and feature_importance have different lengths or invalid input.
     """
     # Convert inputs to numpy arrays if they aren't already
     names = np.asarray(feature_names)
@@ -176,9 +177,9 @@ def plot_features_importance(
     sorted_importance = filtered_importance[sorted_indices]
 
     ax.bar(sorted_names, sorted_importance, **kwargs)
-    ax.set_ylabel('Importance')
+    ax.set_ylabel("Importance")
     if not ax.get_title():
-        ax.set_title('Feature Importance')
+        ax.set_title("Feature Importance")
     plt.xticks(rotation=90)
 
     return ax

--- a/ds_utils/xai.py
+++ b/ds_utils/xai.py
@@ -13,13 +13,13 @@ from sklearn.tree import _tree as sklearn_tree, export_graphviz
 
 
 def _recurse(
-        node: int,
-        depth: int,
-        tree: sklearn_tree.Tree,
-        feature_name: List[str],
-        class_names: Optional[List[str]],
-        output: StringIO,
-        indent_char: str,
+    node: int,
+    depth: int,
+    tree: sklearn_tree.Tree,
+    feature_name: List[str],
+    class_names: Optional[List[str]],
+    output: StringIO,
+    indent_char: str,
 ):
     indent = indent_char * depth
     if tree.feature[node] != sklearn_tree.TREE_UNDEFINED:
@@ -41,11 +41,11 @@ def _recurse(
 
 
 def generate_decision_paths(
-        classifier: BaseDecisionTree,
-        feature_names: Optional[List[str]] = None,
-        class_names: Optional[List[str]] = None,
-        tree_name: Optional[str] = None,
-        indent_char: str = "\t",
+    classifier: BaseDecisionTree,
+    feature_names: Optional[List[str]] = None,
+    class_names: Optional[List[str]] = None,
+    tree_name: Optional[str] = None,
+    indent_char: str = "\t",
 ) -> str:
     """Generate decision rules as text from a decision tree.
 
@@ -78,12 +78,12 @@ def generate_decision_paths(
 
 
 def draw_tree(
-        tree: BaseDecisionTree,
-        feature_names: Optional[List[str]] = None,
-        class_names: Optional[List[str]] = None,
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs,
+    tree: BaseDecisionTree,
+    feature_names: Optional[List[str]] = None,
+    class_names: Optional[List[str]] = None,
+    *,
+    ax: Optional[axes.Axes] = None,
+    **kwargs,
 ) -> axes.Axes:
     """Plot a graph of the decision tree for easy interpretation.
 
@@ -137,11 +137,11 @@ def draw_dot_data(dot_data: str, *, ax: Optional[axes.Axes] = None, **kwargs) ->
 
 
 def plot_features_importance(
-        feature_names: Union[np.ndarray, List[str]],
-        feature_importance: Union[np.ndarray, List[float]],
-        *,
-        ax: Optional[axes.Axes] = None,
-        **kwargs,
+    feature_names: Union[np.ndarray, List[str]],
+    feature_importance: Union[np.ndarray, List[float]],
+    *,
+    ax: Optional[axes.Axes] = None,
+    **kwargs,
 ) -> axes.Axes:
     """Plot feature importance as a bar chart.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,10 @@ extend-select = [
 # For a full list of available rules, see:
 # https://docs.astral.sh/ruff/rules/
 select = ["E", "F", "W"] # Base set: pycodestyle errors, Pyflakes, pycodestyle warnings
-ignore = []
+ignore = [
+    "D203", # one-blank-line-before-class (conflicts with D211)
+    "D213", # multi-line-summary-second-line (conflicts with D212)
+]
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,8 @@ dependencies = [
 ]
 
 [tool.ruff]
-line-length = 88
-# Assume Python 3.10 for now, can be made dynamic if needed or match project minimum.
+line-length = 120
+# Assume Python 3.10 for now, can be made dynamic if necessary an or match project minimum.
 target-version = "py310"
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dependencies = [
     "pytest-xdist==3.6.1",
     "pytest-mpl==0.17.0",
     "kaleido==1.0.0",
-    "ruff===0.12.2"
+    "ruff===0.12.4"
 ]
 
 [tool.hatch.envs.test.env-vars]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@ dependencies = [
     "pytest-cov==6.0.0",
     "pytest-xdist==3.6.1",
     "pytest-mpl==0.17.0",
-    "kaleido==1.0.0"
+    "kaleido==1.0.0",
+    "ruff===0.12.2"
 ]
 
 [tool.hatch.envs.test.env-vars]
@@ -72,9 +73,49 @@ DISPLAY = ":99"
 
 [tool.hatch.envs.test.scripts]
 run = "pytest {args:--mpl --cov-config=.coveragerc --cov=ds_utils --cov-report=xml -n auto}"
+ruff = "python -m ruff {args:.}"
 
 [tool.hatch.envs.dev]
 dependencies = [
     "build==1.2.2.post1",
     "twine==6.1.0",
 ]
+
+[tool.ruff]
+line-length = 88
+# Assume Python 3.10 for now, can be made dynamic if needed or match project minimum.
+target-version = "py310"
+
+[tool.ruff.lint]
+# Extend Ruff's recommended rule set
+extend-select = [
+    "D", # flake8-docstrings
+    "PT", # flake8-pytest-style
+]
+# Enable Pyflakes and pycodestyle rules by default.
+# For a full list of available rules, see:
+# https://docs.astral.sh/ruff/rules/
+select = ["E", "F", "W"] # Base set: pycodestyle errors, Pyflakes, pycodestyle warnings
+ignore = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"
+
+[tool.ruff.lint.isort]
+# Sort imports within sections alphabetically.
+# Ensure that from imports are grouped together.
+force-sort-within-sections = true
+# Combine as imports when sorting.
+combine-as-imports = true
+# Known first party imports (your project's modules)
+known-first-party = ["ds_utils", "tests"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Data Science Utilities package."""

--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -1,3 +1,5 @@
+"""Tests for mathematical utility functions."""
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -24,7 +26,7 @@ def test_valid_series(sample_data):
 
 
 def test_valid_array(sample_data):
-    """Test percentile calculation with valid numpy array."""
+    """Test percentile calculation with a valid numpy array."""
     _, array = sample_data
     assert safe_percentile(array, 50) == 3.0
     assert safe_percentile(array, 0) == 1.0
@@ -32,19 +34,27 @@ def test_valid_array(sample_data):
     assert isinstance(safe_percentile(array, 50), np.floating)
 
 
-@pytest.mark.parametrize("x, expected",
-                         [
-                             (pd.Series([1.0, np.nan, 3.0, None, 5.0]), 3.0),
-                             (np.array([1.0, np.nan, 3.0, np.nan, 5.0]), 3.0),
-                             (pd.Series([np.nan, None, pd.NA]), None),
-                             (np.array([np.nan, np.nan, np.nan]), None),
-                             (pd.Series([]), None),
-                             (np.array([]), None)
-                         ],
-                         ids=["test_series_with_na", "test_array_with_nan", "test_all_na_series",
-                              "test_all_nan_array", "test_empty_series", "test_empty_array"])
+@pytest.mark.parametrize(
+    ("x", "expected"),
+    [
+        (pd.Series([1.0, np.nan, 3.0, None, 5.0]), 3.0),
+        (np.array([1.0, np.nan, 3.0, np.nan, 5.0]), 3.0),
+        (pd.Series([np.nan, None, pd.NA]), None),
+        (np.array([np.nan, np.nan, np.nan]), None),
+        (pd.Series([]), None),
+        (np.array([]), None),
+    ],
+    ids=[
+        "test_series_with_na",
+        "test_array_with_nan",
+        "test_all_na_series",
+        "test_all_nan_array",
+        "test_empty_series",
+        "test_empty_array",
+    ],
+)
 def test_with_na(x, expected):
-    """Test percentile calculation with pandas Series containing NA values."""
+    """Test percentile calculation with pandas' Series containing NA values."""
     assert safe_percentile(x, 50) == expected
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,3 +1,5 @@
+"""Tests for model evaluation metrics and visualizations."""
+
 import json
 from pathlib import Path
 from typing import Dict, Union, Any
@@ -15,7 +17,8 @@ from ds_utils.metrics import (
     plot_confusion_matrix,
     plot_metric_growth_per_labeled_instances,
     visualize_accuracy_grouped_by_probability,
-    plot_roc_curve_with_thresholds_annotations, plot_precision_recall_curve_with_thresholds_annotations
+    plot_roc_curve_with_thresholds_annotations,
+    plot_precision_recall_curve_with_thresholds_annotations,
 )
 
 BASELINE_DIR = Path(__file__).parent / "baseline_images" / "test_metrics"
@@ -27,8 +30,7 @@ RESOURCES_DIR = Path(__file__).parent / "resources"
 def iris_data() -> Dict[str, np.ndarray]:
     """Load and return iris dataset splits."""
     return {
-        key: pd.read_csv(RESOURCES_DIR / f"iris_{key}.csv").values
-        for key in ["x_train", "x_test", "y_train", "y_test"]
+        key: pd.read_csv(RESOURCES_DIR / f"iris_{key}.csv").values for key in ["x_train", "x_test", "y_train", "y_test"]
     }
 
 
@@ -37,7 +39,7 @@ def classifiers() -> Dict[str, Union[DecisionTreeClassifier, RandomForestClassif
     """Create and return classifier instances."""
     return {
         "DecisionTreeClassifier": DecisionTreeClassifier(random_state=0),
-        "RandomForestClassifier": RandomForestClassifier(random_state=0, n_estimators=5)
+        "RandomForestClassifier": RandomForestClassifier(random_state=0, n_estimators=5),
     }
 
 
@@ -50,7 +52,7 @@ def plotly_models_dict() -> Dict[str, Any]:
 
 @pytest.fixture(autouse=True)
 def setup_teardown():
-    """Setup and teardown for tests."""
+    """Set up and tear down for tests."""
     RESULT_DIR.mkdir(exist_ok=True, parents=True)
     yield
     plt.close("all")  # Close all figures instead of just current
@@ -67,58 +69,81 @@ def save_plotly_figure_and_return_matplot(fig: go.Figure, path_to_save: Path) ->
 
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
-@pytest.mark.parametrize("custom_y_test, custom_y_pred, labels", [
-    ("1 1 1 1 1 0 1 0 1 0 0 1 0 0 1 0 0 0 1 0 1 0 0 1 1 1 1 1 0 0 0 1 0 1 0 1 0 0 0 0 1 1 1 1 0 1 1 0 1 0",
-     "0 1 1 1 1 0 0 0 1 0 0 0 0 1 1 0 1 1 0 0 1 0 0 1 1 0 1 1 0 0 0 1 0 1 0 1 1 0 1 0 1 1 1 1 0 1 1 1 1 1",
-     [1, 0]),
-    ("1 0 1 1 0 0 0 0 2 2 1 1 1 2 2 0 1 0 0 1 1 2 2 2 2 1 1 0 1 1 0 0 2 0 1 1 0 2 1 2 2 1 2 1 0 0 0 1 0 2 1 0 "
-     "1 2 2 2 1 1 2 2 1 2 1 0 1 1 2 0 0 2 0 2 1 2 0",
-     "0 0 2 2 2 0 1 0 1 2 2 2 2 2 2 0 2 1 2 2 0 2 2 2 1 1 2 0 1 2 0 2 2 0 2 2 2 2 2 2 2 0 2 1 0 0 1 1 1 0 1 1 2 "
-     "0 1 2 0 0 0 2 2 2 2 0 0 2 2 1 0 2 0 0 2 0 2",
-     [0, 1, 2])
-], ids=["binary", "multiclass"])
+@pytest.mark.parametrize(
+    ("custom_y_test", "custom_y_pred", "labels"),
+    [
+        (
+            "1 1 1 1 1 0 1 0 1 0 0 1 0 0 1 0 0 0 1 0 1 0 0 1 1 1 1 1 0 0 0 1 0 1 0 1 0 0 0 0 1 1 1 1 0 1 1 0 1 0",
+            "0 1 1 1 1 0 0 0 1 0 0 0 0 1 1 0 1 1 0 0 1 0 0 1 1 0 1 1 0 0 0 1 0 1 0 1 1 0 1 0 1 1 1 1 0 1 1 1 1 1",
+            [1, 0],
+        ),
+        (
+            "1 0 1 1 0 0 0 0 2 2 1 1 1 2 2 0 1 0 0 1 1 2 2 2 2 1 1 0 1 1 0 0 2 0 1 1 0 2 1 2 2 1 2 1 0 0 0 1 0 2 1 0 "
+            "1 2 2 2 1 1 2 2 1 2 1 0 1 1 2 0 0 2 0 2 1 2 0",
+            "0 0 2 2 2 0 1 0 1 2 2 2 2 2 2 0 2 1 2 2 0 2 2 2 1 1 2 0 1 2 0 2 2 0 2 2 2 2 2 2 2 0 2 1 0 0 1 1 1 0 1 1 2 "
+            "0 1 2 0 0 0 2 2 2 2 0 0 2 2 1 0 2 0 0 2 0 2",
+            [0, 1, 2],
+        ),
+    ],
+    ids=["binary", "multiclass"],
+)
 def test_plot_confusion_matrix(custom_y_test, custom_y_pred, labels):
-    y_test = np.fromstring(custom_y_test, dtype=int, sep=' ')
-    y_pred = np.fromstring(custom_y_pred, dtype=int, sep=' ')
+    """Test plotting of confusion matrix for binary and multiclass cases."""
+    y_test = np.fromstring(custom_y_test, dtype=int, sep=" ")
+    y_pred = np.fromstring(custom_y_pred, dtype=int, sep=" ")
 
     ax = plot_confusion_matrix(y_test, y_pred, labels)
 
     # Assert that the confusion matrix is correctly calculated
-    cm = ax[1].get_children()[0].get_array().data[:len(labels), :len(labels)]
-    np.testing.assert_array_equal(cm,
-                                  np.array([[np.sum((y_test == i) & (y_pred == j)) for j in labels] for i in labels]))
+    cm = ax[1].get_children()[0].get_array().data[: len(labels), : len(labels)]
+    np.testing.assert_array_equal(
+        cm, np.array([[np.sum((y_test == i) & (y_pred == j)) for j in labels] for i in labels])
+    )
 
     # Assert that the accuracy and F1 score are correctly calculated
-    accuracy = float(ax[2].texts[0].get_text().split(': ')[1])
+    accuracy = float(ax[2].texts[0].get_text().split(": ")[1])
     assert accuracy == np.mean(y_test == y_pred)
 
     return plt.gcf()
 
 
 def test_print_confusion_matrix_exception():
-    with pytest.raises(ValueError):
+    """Test plot_confusion_matrix raises ValueError for invalid labels."""
+    with pytest.raises(ValueError, match="Number of labels must be greater than 1"):
         plot_confusion_matrix(np.array([]), np.array([]), [])
 
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
-@pytest.mark.parametrize("n_samples, quantiles, random_state", [
-    (None, np.linspace(0.05, 1, 20).tolist(), 42),
-    (None, np.linspace(0.05, 1, 20).tolist(), 42),
-    (list(range(10, 100, 10)), None, 42),
-    (None, np.linspace(0.05, 1, 20).tolist(), 1),
-    (None, np.linspace(0.05, 1, 20).tolist(), RandomState(5))
-], ids=["no_n_samples", "y_shape_n_outputs", "with_n_samples", "given_random_state_int", "given_random_state"])
-def test_plot_metric_growth_per_labeled_instances(iris_data, classifiers, n_samples, quantiles, random_state,
-                                                  request):
-    if request.node.callspec.id == "y_shape_n_outputs":
+@pytest.mark.parametrize(
+    ("n_samples", "quantiles", "random_state", "use_dummies"),
+    [
+        (None, np.linspace(0.05, 1, 20).tolist(), 42, False),
+        (None, np.linspace(0.05, 1, 20).tolist(), 42, True),  # This is the y_shape_n_outputs case
+        (list(range(10, 100, 10)), None, 42, False),
+        (None, np.linspace(0.05, 1, 20).tolist(), 1, False),
+        (None, np.linspace(0.05, 1, 20).tolist(), RandomState(5), False),
+    ],
+    ids=["no_n_samples", "y_shape_n_outputs", "with_n_samples", "given_random_state_int", "given_random_state"],
+)
+def test_plot_metric_growth_per_labeled_instances(
+    iris_data, classifiers, n_samples, quantiles, random_state, use_dummies
+):
+    """Test plotting metric growth with various samples, quantiles, random states."""
+    if use_dummies:
         y_train = pd.get_dummies(pd.DataFrame(iris_data["y_train"]).astype(str))
         y_test = pd.get_dummies(pd.DataFrame(iris_data["y_test"]).astype(str))
     else:
         y_train, y_test = iris_data["y_train"], iris_data["y_test"]
 
     ax = plot_metric_growth_per_labeled_instances(
-        iris_data["x_train"], y_train, iris_data["x_test"], y_test,
-        classifiers, n_samples=n_samples, quantiles=quantiles, random_state=random_state
+        iris_data["x_train"],
+        y_train,
+        iris_data["x_test"],
+        y_test,
+        classifiers,
+        n_samples=n_samples,
+        quantiles=quantiles,
+        random_state=random_state,
     )
 
     # Assert that the number of lines in the plot matches the number of classifiers
@@ -134,22 +159,32 @@ def test_plot_metric_growth_per_labeled_instances(iris_data, classifiers, n_samp
 
 
 def test_plot_metric_growth_per_labeled_instances_no_n_samples_no_quantiles(iris_data, classifiers):
-    with pytest.raises(ValueError):
+    """Test ValueError if both n_samples and quantiles are None."""
+    with pytest.raises(ValueError, match="n_samples must be specified if quantiles is None"):
         plot_metric_growth_per_labeled_instances(
-            iris_data["x_train"], iris_data["y_train"],
-            iris_data["x_test"], iris_data["y_test"],
-            classifiers, n_samples=None, quantiles=None
+            iris_data["x_train"],
+            iris_data["y_train"],
+            iris_data["x_test"],
+            iris_data["y_test"],
+            classifiers,
+            n_samples=None,
+            quantiles=None,
         )
 
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_plot_metric_growth_per_labeled_instances_exists_ax(iris_data, classifiers):
+    """Test plotting metric growth on an existing Axes object."""
     fig, ax = plt.subplots()
     ax.set_title("My ax")
     plot_metric_growth_per_labeled_instances(
-        iris_data["x_train"], iris_data["y_train"],
-        iris_data["x_test"], iris_data["y_test"],
-        classifiers, ax=ax, random_state=42
+        iris_data["x_train"],
+        iris_data["y_train"],
+        iris_data["x_test"],
+        iris_data["y_test"],
+        classifiers,
+        ax=ax,
+        random_state=42,
     )
 
     assert ax.get_title() == "My ax"
@@ -158,30 +193,34 @@ def test_plot_metric_growth_per_labeled_instances_exists_ax(iris_data, classifie
 
 
 def test_plot_metric_growth_per_labeled_instances_verbose(iris_data, classifiers, capsys):
+    """Test verbose output of plot_metric_growth_per_labeled_instances."""
     plot_metric_growth_per_labeled_instances(
-        iris_data["x_train"], iris_data["y_train"],
-        iris_data["x_test"], iris_data["y_test"],
-        classifiers, verbose=1
+        iris_data["x_train"], iris_data["y_train"], iris_data["x_test"], iris_data["y_test"], classifiers, verbose=1
     )
     captured = capsys.readouterr().out
-    expected = ("Fitting classifier DecisionTreeClassifier for 20 times\nFitting classifier RandomForestClassifier"
-                " for 20 times\n")
+    expected = (
+        "Fitting classifier DecisionTreeClassifier for 20 times\nFitting classifier RandomForestClassifier"
+        " for 20 times\n"
+    )
     assert captured == expected
 
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
-@pytest.mark.parametrize("display_breakdown, bins, threshold", [
-    (False, None, 0.5),
-    (True, None, 0.5),
-    (False, [0, 0.3, 0.5, 0.8, 1], 0.5),
-    (False, None, 0.3)
-], ids=["default", "with_breakdown", "custom_bins", "custom_threshold"])
+@pytest.mark.parametrize(
+    ("display_breakdown", "bins", "threshold"),
+    [(False, None, 0.5), (True, None, 0.5), (False, [0, 0.3, 0.5, 0.8, 1], 0.5), (False, None, 0.3)],
+    ids=["default", "with_breakdown", "custom_bins", "custom_threshold"],
+)
 def test_visualize_accuracy_grouped_by_probability(display_breakdown, bins, threshold):
+    """Test visualizing accuracy grouped by probability with different parameters."""
     class_with_probabilities = pd.read_csv(Path(__file__).parent.joinpath("resources", "class_with_probabilities.csv"))
     ax = visualize_accuracy_grouped_by_probability(
-        class_with_probabilities["loan_condition_cat"], 1,
+        class_with_probabilities["loan_condition_cat"],
+        1,
         class_with_probabilities["probabilities"],
-        display_breakdown=display_breakdown, bins=bins, threshold=threshold
+        display_breakdown=display_breakdown,
+        bins=bins,
+        threshold=threshold,
     )
 
     # Assert that the x-axis label is correct
@@ -200,13 +239,13 @@ def test_visualize_accuracy_grouped_by_probability(display_breakdown, bins, thre
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_visualize_accuracy_grouped_by_probability_exists_ax():
+    """Test visualizing accuracy grouped by probability on an existing Axes object."""
     fig, ax = plt.subplots()
     ax.set_title("My ax")
 
     class_with_probabilities = pd.read_csv(Path(__file__).parent.joinpath("resources", "class_with_probabilities.csv"))
     visualize_accuracy_grouped_by_probability(
-        class_with_probabilities["loan_condition_cat"], 1,
-        class_with_probabilities["probabilities"], ax=ax
+        class_with_probabilities["loan_condition_cat"], 1, class_with_probabilities["probabilities"], ax=ax
     )
 
     assert ax.get_title() == "My ax"
@@ -219,9 +258,11 @@ def test_visualize_accuracy_grouped_by_probability_exists_ax():
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR, tolerance=18)
 @pytest.mark.parametrize("add_random_classifier_line", [True, False], ids=["default", "without_random_classifier"])
 def test_plot_roc_curve_with_thresholds_annotations(mocker, request, add_random_classifier_line, plotly_models_dict):
+    """Test ROC curve plotting when underlying calculations fail."""
     y_true = np.array(plotly_models_dict["y_true"])
-    classifiers_names_and_scores_dict = {name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items()
-                                         if name != "y_true"}
+    classifiers_names_and_scores_dict = {
+        name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items() if name != "y_true"
+    }
 
     def _mock_roc_curve(y_true, y_score, **kwargs):
         for classifier, scores in classifiers_names_and_scores_dict.items():
@@ -239,9 +280,7 @@ def test_plot_roc_curve_with_thresholds_annotations(mocker, request, add_random_
     mocker.patch("ds_utils.metrics.roc_auc_score", side_effect=_mock_roc_auc_score)
 
     fig = plot_roc_curve_with_thresholds_annotations(
-        y_true,
-        classifiers_names_and_scores_dict,
-        add_random_classifier_line=add_random_classifier_line
+        y_true, classifiers_names_and_scores_dict, add_random_classifier_line=add_random_classifier_line
     )
 
     return save_plotly_figure_and_return_matplot(fig, RESULT_DIR / f"{request.node.name}.png")
@@ -249,12 +288,14 @@ def test_plot_roc_curve_with_thresholds_annotations(mocker, request, add_random_
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR, tolerance=16)
 def test_plot_roc_curve_with_thresholds_annotations_exist_figure(mocker, request, plotly_models_dict):
+    """Test plotting ROC curve on an existing Figure object."""
     fig = go.Figure()
     fig.update_layout(title="Receiver Operating Characteristic (ROC) Curve")
 
     y_true = np.array(plotly_models_dict["y_true"])
-    classifiers_names_and_scores_dict = {name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items()
-                                         if name != "y_true"}
+    classifiers_names_and_scores_dict = {
+        name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items() if name != "y_true"
+    }
 
     def _mock_roc_curve(y_true, y_score, **kwargs):
         for classifier, scores in classifiers_names_and_scores_dict.items():
@@ -272,42 +313,47 @@ def test_plot_roc_curve_with_thresholds_annotations_exist_figure(mocker, request
     mocker.patch("ds_utils.metrics.roc_auc_score", side_effect=_mock_roc_auc_score)
 
     fig = plot_roc_curve_with_thresholds_annotations(
-        y_true,
-        classifiers_names_and_scores_dict,
-        add_random_classifier_line=True,
-        fig=fig
+        y_true, classifiers_names_and_scores_dict, add_random_classifier_line=True, fig=fig
     )
 
     return save_plotly_figure_and_return_matplot(fig, RESULT_DIR / f"{request.node.name}.png")
 
 
-@pytest.mark.parametrize("plotly_graph_method", [plot_roc_curve_with_thresholds_annotations,
-                                                 plot_precision_recall_curve_with_thresholds_annotations],
-                         ids=["plot_roc_curve_with_thresholds_annotations",
-                              "plot_precision_recall_curve_with_thresholds_annotations"])
+@pytest.mark.parametrize(
+    "plotly_graph_method",
+    [plot_roc_curve_with_thresholds_annotations, plot_precision_recall_curve_with_thresholds_annotations],
+    ids=["plot_roc_curve_with_thresholds_annotations", "plot_precision_recall_curve_with_thresholds_annotations"],
+)
 def test_plotly_graph_method_shape_mismatch(plotly_graph_method, plotly_models_dict):
+    """Test that plotly graph methods raise ValueError for shape mismatches."""
     y_true = np.array(plotly_models_dict["y_true"][:1])
-    classifiers_names_and_scores_dict = {name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items()
-                                         if name != "y_true"}
-    with pytest.raises(ValueError,
-                       match=r"Shape mismatch: y_true \(1,\) and y_scores \(2239,\) for classifier Decision Tree"):
-        plotly_graph_method(
-            y_true,
-            classifiers_names_and_scores_dict
-        )
+    classifiers_names_and_scores_dict = {
+        name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items() if name != "y_true"
+    }
+    with pytest.raises(
+        ValueError, match=r"Shape mismatch: y_true \(1,\) and y_scores \(2239,\) for classifier Decision Tree"
+    ):
+        plotly_graph_method(y_true, classifiers_names_and_scores_dict)
 
 
-@pytest.mark.parametrize("error, message",
-                         [(ValueError, "Error calculating ROC curve for classifier Decision Tree:"),
-                          (ValueError, "Error calculating AUC score for classifier Decision Tree:")],
-                         ids=["roc_calc_fail", "auc_calc_fail"])
+@pytest.mark.parametrize(
+    ("error", "message"),
+    [
+        (ValueError, "Error calculating ROC curve for classifier Decision Tree:"),
+        (ValueError, "Error calculating AUC score for classifier Decision Tree:"),
+    ],
+    ids=["roc_calc_fail", "auc_calc_fail"],
+)
 def test_plot_roc_curve_with_thresholds_annotations_fail_calc(mocker, request, error, message, plotly_models_dict):
+    """Test ROC curve plotting when underlying calculations fail."""
     y_true = np.array(plotly_models_dict["y_true"])
-    classifiers_names_and_scores_dict = {name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items()
-                                         if name != "y_true"}
+    classifiers_names_and_scores_dict = {
+        name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items() if name != "y_true"
+    }
     if request.node.callspec.id == "roc_calc_fail":
         mocker.patch("ds_utils.metrics.roc_curve", side_effect=ValueError)
     elif request.node.callspec.id == "auc_calc_fail":
+
         def _mock_roc_curve(y_true, y_score, **kwargs):
             for classifier, scores in classifiers_names_and_scores_dict.items():
                 if np.array_equal(scores, y_score):
@@ -318,19 +364,19 @@ def test_plot_roc_curve_with_thresholds_annotations_fail_calc(mocker, request, e
 
         mocker.patch("ds_utils.metrics.roc_auc_score", side_effect=ValueError)
     with pytest.raises(error, match=message):
-        plot_roc_curve_with_thresholds_annotations(
-            y_true,
-            classifiers_names_and_scores_dict
-        )
+        plot_roc_curve_with_thresholds_annotations(y_true, classifiers_names_and_scores_dict)
 
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR, tolerance=18)
 @pytest.mark.parametrize("add_random_classifier_line", [False, True], ids=["default", "with_random_classifier_line"])
-def test_plot_precision_recall_curve_with_thresholds_annotations(mocker, request, add_random_classifier_line,
-                                                                 plotly_models_dict):
+def test_plot_precision_recall_curve_with_thresholds_annotations(
+    mocker, request, add_random_classifier_line, plotly_models_dict
+):
+    """Test plotting a Precision-Recall curve with threshold annotations."""
     y_true = np.array(plotly_models_dict["y_true"])
-    classifiers_names_and_scores_dict = {name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items()
-                                         if name != "y_true"}
+    classifiers_names_and_scores_dict = {
+        name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items() if name != "y_true"
+    }
 
     def _mock_precision_recall_curve(y_true, y_score, **kwargs):
         for classifier, scores in classifiers_names_and_scores_dict.items():
@@ -341,9 +387,7 @@ def test_plot_precision_recall_curve_with_thresholds_annotations(mocker, request
     mocker.patch("ds_utils.metrics.precision_recall_curve", side_effect=_mock_precision_recall_curve)
 
     fig = plot_precision_recall_curve_with_thresholds_annotations(
-        y_true,
-        classifiers_names_and_scores_dict,
-        add_random_classifier_line=add_random_classifier_line
+        y_true, classifiers_names_and_scores_dict, add_random_classifier_line=add_random_classifier_line
     )
 
     return save_plotly_figure_and_return_matplot(fig, RESULT_DIR / f"{request.node.name}.png")
@@ -351,12 +395,14 @@ def test_plot_precision_recall_curve_with_thresholds_annotations(mocker, request
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR, tolerance=15)
 def test_plot_precision_recall_curve_with_thresholds_annotations_exists_figure(mocker, request, plotly_models_dict):
+    """Test plotting a Precision-Recall curve on an existing Figure object."""
     fig = go.Figure()
     fig.update_layout(title="Precision-Recall Curve")
 
     y_true = np.array(plotly_models_dict["y_true"])
-    classifiers_names_and_scores_dict = {name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items()
-                                         if name != "y_true"}
+    classifiers_names_and_scores_dict = {
+        name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items() if name != "y_true"
+    }
 
     def _mock_precision_recall_curve(y_true, y_score, **kwargs):
         for classifier, scores in classifiers_names_and_scores_dict.items():
@@ -366,23 +412,18 @@ def test_plot_precision_recall_curve_with_thresholds_annotations_exists_figure(m
 
     mocker.patch("ds_utils.metrics.precision_recall_curve", side_effect=_mock_precision_recall_curve)
 
-    fig = plot_precision_recall_curve_with_thresholds_annotations(
-        y_true,
-        classifiers_names_and_scores_dict,
-        fig=fig
-    )
+    fig = plot_precision_recall_curve_with_thresholds_annotations(y_true, classifiers_names_and_scores_dict, fig=fig)
 
     return save_plotly_figure_and_return_matplot(fig, RESULT_DIR / f"{request.node.name}.png")
 
 
 def test_plot_precision_recall_curve_with_thresholds_annotations_fail_calc(mocker, plotly_models_dict):
+    """Test Precision-Recall curve plotting when underlying calculations fail."""
     y_true = np.array(plotly_models_dict["y_true"])
-    classifiers_names_and_scores_dict = {name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items()
-                                         if name != "y_true"}
+    classifiers_names_and_scores_dict = {
+        name: np.array(data["y_scores"]) for name, data in plotly_models_dict.items() if name != "y_true"
+    }
 
     mocker.patch("ds_utils.metrics.precision_recall_curve", side_effect=ValueError)
     with pytest.raises(ValueError, match="Error calculating Precision-Recall curve for classifier Decision Tree:"):
-        plot_precision_recall_curve_with_thresholds_annotations(
-            y_true,
-            classifiers_names_and_scores_dict
-        )
+        plot_precision_recall_curve_with_thresholds_annotations(y_true, classifiers_names_and_scores_dict)

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,3 +1,5 @@
+"""Tests for data preprocessing functions and visualizations."""
+
 from pathlib import Path
 
 import numpy as np
@@ -12,50 +14,59 @@ from ds_utils.preprocess import (
     plot_correlation_dendrogram,
     visualize_feature,
     get_correlated_features,
-    extract_statistics_dataframe_per_label
+    extract_statistics_dataframe_per_label,
 )
 
 RESOURCES_PATH = Path(__file__).parent / "resources"
 BASELINE_DIR = Path(__file__).parent / "baseline_images" / "test_preprocess"
 
 
-@pytest.fixture()
+@pytest.fixture
 def loan_data():
-    return pd.read_csv(RESOURCES_PATH.joinpath("loan_final313.csv"),
-                       encoding="latin1", parse_dates=["issue_d"]).drop("id", axis=1)
+    """Load and return loan dataset for testing."""
+    return pd.read_csv(RESOURCES_PATH.joinpath("loan_final313.csv"), encoding="latin1", parse_dates=["issue_d"]).drop(
+        "id", axis=1
+    )
 
 
-@pytest.fixture()
+@pytest.fixture
 def data_1m():
-    return pd.read_csv(RESOURCES_PATH.joinpath("data.1M.zip"), compression='zip')
+    """Load and return 1M dataset for testing."""
+    return pd.read_csv(RESOURCES_PATH.joinpath("data.1M.zip"), compression="zip")
 
 
-@pytest.fixture()
+@pytest.fixture
 def daily_min_temperatures():
+    """Load and return daily minimum temperatures dataset for testing."""
     return pd.read_csv(RESOURCES_PATH.joinpath("daily-min-temperatures.csv"), parse_dates=["Date"])
 
 
 @pytest.fixture
 def sample_df() -> pd.DataFrame:
     """Create a sample DataFrame for testing."""
-    return pd.DataFrame({
-        'value': [1.0, 2.0, 3.0, 4.0, 5.0, np.nan, 7.0, 8.0, 9.0, 10.0],
-        'category': ['A', 'A', 'A', 'B', 'B', 'B', 'C', 'C', 'C', 'C'],
-        'text_col': ['x', 'y', 'z', 'x', 'y', 'z', 'x', 'y', 'z', 'x']
-    })
+    return pd.DataFrame(
+        {
+            "value": [1.0, 2.0, 3.0, 4.0, 5.0, np.nan, 7.0, 8.0, 9.0, 10.0],
+            "category": ["A", "A", "A", "B", "B", "B", "C", "C", "C", "C"],
+            "text_col": ["x", "y", "z", "x", "y", "z", "x", "y", "z", "x"],
+        }
+    )
+
 
 @pytest.fixture(autouse=True)
 def setup_teardown():
+    """Set up and tear down for each test function in this module."""
     yield
     plt.cla()
     plt.close(plt.gcf())
 
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
-@pytest.mark.parametrize("feature",
-                         ["emp_length_int", "issue_d", "loan_condition_cat", "income_category", "home_ownership",
-                          "purpose"],
-                         ids=["float", "datetime", "int", "object", "category", "category_more_than_10_categories"])
+@pytest.mark.parametrize(
+    "feature",
+    ["emp_length_int", "issue_d", "loan_condition_cat", "income_category", "home_ownership", "purpose"],
+    ids=["float", "datetime", "int", "object", "category", "category_more_than_10_categories"],
+)
 def test_visualize_feature(loan_data, feature, request):
     """Test visualize_feature function for different feature types."""
     visualize_feature(loan_data[feature])
@@ -70,6 +81,7 @@ def test_visualize_feature(loan_data, feature, request):
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_visualize_feature_float_exist_ax(loan_data):
+    """Test visualize_feature with a float feature on an existing Axes."""
     fig, ax = plt.subplots()
     ax.set_title("My ax")
 
@@ -92,10 +104,9 @@ def test_visualize_feature_bool(loan_data):
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_visualize_feature_remove_na(loan_data):
     """Test visualize_feature function with NA values removed."""
-    loan_data_dup = pd.concat([
-        loan_data[["emp_length_int"]],
-        pd.DataFrame([np.nan] * 250, columns=["emp_length_int"])
-    ], ignore_index=True).sample(frac=1, random_state=0)
+    loan_data_dup = pd.concat(
+        [loan_data[["emp_length_int"]], pd.DataFrame([np.nan] * 250, columns=["emp_length_int"])], ignore_index=True
+    ).sample(frac=1, random_state=0)
 
     visualize_feature(loan_data_dup["emp_length_int"], remove_na=True)
     return plt.gcf()
@@ -120,22 +131,37 @@ def test_visualize_correlations(data_1m, use_existing_ax):
 
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
-@pytest.mark.parametrize("feature1, feature2, data_fixture", [
-    ("x4", "x5", "data_1m"),
-    ("x1", "x7", "data_1m"),
-    ("x7", "x1", "data_1m"),
-    ("x1", "x12", "data_1m"),
-    ("x7", "x10", "data_1m"),
-    ("x10", "x12", "data_1m"),
-    ("Date", "Temp", "daily_min_temperatures"),
-    ("Temp", "Date", "daily_min_temperatures"),
-    ("issue_d", "issue_d", "loan_data"),
-    ("issue_d", "home_ownership", "loan_data"),
-    ("home_ownership", "issue_d", "loan_data"),
-    ("x12", "x12", "data_1m")
-], ids=["both_numeric", "numeric_categorical", "numeric_categorical_reverse", "numeric_boolean", "both_categorical",
-        "categorical_bool", "datetime_numeric", "datetime_numeric_reverse", "datetime_datetime", "datetime_categorical",
-        "datetime_categorical_reverse", "both_bool"])
+@pytest.mark.parametrize(
+    ("feature1", "feature2", "data_fixture"),
+    [
+        ("x4", "x5", "data_1m"),
+        ("x1", "x7", "data_1m"),
+        ("x7", "x1", "data_1m"),
+        ("x1", "x12", "data_1m"),
+        ("x7", "x10", "data_1m"),
+        ("x10", "x12", "data_1m"),
+        ("Date", "Temp", "daily_min_temperatures"),
+        ("Temp", "Date", "daily_min_temperatures"),
+        ("issue_d", "issue_d", "loan_data"),
+        ("issue_d", "home_ownership", "loan_data"),
+        ("home_ownership", "issue_d", "loan_data"),
+        ("x12", "x12", "data_1m"),
+    ],
+    ids=[
+        "both_numeric",
+        "numeric_categorical",
+        "numeric_categorical_reverse",
+        "numeric_boolean",
+        "both_categorical",
+        "categorical_bool",
+        "datetime_numeric",
+        "datetime_numeric_reverse",
+        "datetime_datetime",
+        "datetime_categorical",
+        "datetime_categorical_reverse",
+        "both_bool",
+    ],
+)
 def test_plot_relationship_between_features(feature1, feature2, data_fixture, request):
     """Test plot_features_interaction function for various feature combinations."""
     data = request.getfixturevalue(data_fixture)
@@ -156,10 +182,13 @@ def test_plot_relationship_between_features(feature1, feature2, data_fixture, re
 
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
-@pytest.mark.parametrize("feature1, feature2",
-                         [("issue_d", "loan_condition_cat"), ("loan_condition_cat", "issue_d")],
-                         ids=["default", "reverse"])
+@pytest.mark.parametrize(
+    ("feature1", "feature2"),
+    [("issue_d", "loan_condition_cat"), ("loan_condition_cat", "issue_d")],
+    ids=["default", "reverse"],
+)
 def test_plot_relationship_between_features_datetime_bool(loan_data, feature1, feature2):
+    """Test interaction plot between a datetime and a boolean feature."""
     df = pd.DataFrame()
     df["loan_condition_cat"] = loan_data["loan_condition_cat"].astype("bool")
     df["issue_d"] = loan_data["issue_d"]
@@ -173,6 +202,7 @@ def test_plot_relationship_between_features_datetime_bool(loan_data, feature1, f
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_plot_relationship_between_features_both_numeric_exist_ax(data_1m):
+    """Test interaction plot for two numeric features on an existing Axes."""
     fig, ax = plt.subplots()
     ax.set_title("My ax")
 
@@ -200,21 +230,34 @@ def test_plot_correlation_dendrogram(data_1m, use_existing_ax):
 def test_get_correlated_features():
     """Test get_correlated_features function."""
     correlations = pd.read_feather(RESOURCES_PATH.joinpath("loan_final313_small_corr.feather"))
-    correlation = get_correlated_features(correlations, correlations.columns.drop("loan_condition_cat").tolist(),
-                                          "loan_condition_cat", 0.95)
-    correlation_expected = pd.DataFrame([
-        {'level_0': 'income_category_Low', 'level_1': 'income_category_Medium',
-         'level_0_level_1_corr': 1.0,
-         'level_0_target_corr': 0.11821656093586508,
-         'level_1_target_corr': 0.11821656093586504},
-        {'level_0': 'term_ 36 months', 'level_1': 'term_ 60 months',
-         'level_0_level_1_corr': 1.0,
-         'level_0_target_corr': 0.223606797749979,
-         'level_1_target_corr': 0.223606797749979},
-        {'level_0': 'interest_payments_High', 'level_1': 'interest_payments_Low',
-         'level_0_level_1_corr': 1.0, 'level_0_target_corr': 0.13363062095621223,
-         'level_1_target_corr': 0.13363062095621223}
-    ])
+    correlation = get_correlated_features(
+        correlations, correlations.columns.drop("loan_condition_cat").tolist(), "loan_condition_cat", 0.95
+    )
+    correlation_expected = pd.DataFrame(
+        [
+            {
+                "level_0": "income_category_Low",
+                "level_1": "income_category_Medium",
+                "level_0_level_1_corr": 1.0,
+                "level_0_target_corr": 0.11821656093586508,
+                "level_1_target_corr": 0.11821656093586504,
+            },
+            {
+                "level_0": "term_ 36 months",
+                "level_1": "term_ 60 months",
+                "level_0_level_1_corr": 1.0,
+                "level_0_target_corr": 0.223606797749979,
+                "level_1_target_corr": 0.223606797749979,
+            },
+            {
+                "level_0": "interest_payments_High",
+                "level_1": "interest_payments_Low",
+                "level_0_level_1_corr": 1.0,
+                "level_0_target_corr": 0.13363062095621223,
+                "level_1_target_corr": 0.13363062095621223,
+            },
+        ]
+    )
     pd.testing.assert_frame_equal(correlation_expected, correlation)
 
 
@@ -223,37 +266,57 @@ def test_get_correlated_features_empty_result():
     correlations = pd.read_feather(RESOURCES_PATH.joinpath("clothing_classification_train_corr.feather"))
     expected_warning = "Correlation threshold 0.95 was too high. An empty frame was returned"
     with pytest.warns(UserWarning, match=expected_warning):
-        correlation = get_correlated_features(correlations,
-                                              ["Clothing ID", "Age", "Title", "Review Text", "Rating",
-                                               "Recommended IND", "Positive Feedback Count", "Division Name",
-                                               "Department Name"],
-                                              "Class Name", 0.95)
+        correlation = get_correlated_features(
+            correlations,
+            [
+                "Clothing ID",
+                "Age",
+                "Title",
+                "Review Text",
+                "Rating",
+                "Recommended IND",
+                "Positive Feedback Count",
+                "Division Name",
+                "Department Name",
+            ],
+            "Class Name",
+            0.95,
+        )
     correlation_expected = pd.DataFrame(
-        columns=['level_0', 'level_1', 'level_0_level_1_corr', 'level_0_target_corr', 'level_1_target_corr'])
+        columns=["level_0", "level_1", "level_0_level_1_corr", "level_0_target_corr", "level_1_target_corr"]
+    )
     pd.testing.assert_frame_equal(correlation_expected, correlation)
 
 
 def assert_series_called_with(mock_calls, expected_series, percentile):
-    """Helper function to check if a pandas Series was called with specific values."""
+    """Check if a pandas' Series was called with specific values."""
     for args, _ in mock_calls:
         series, p = args
-        if (p == percentile and
-                isinstance(series, pd.Series) and
-                series.equals(expected_series)):
+        if p == percentile and isinstance(series, pd.Series) and series.equals(expected_series):
             return True
     return False
 
 
 def test_extract_statistics_dataframe_per_label_basic_functionality(sample_df, mocker):
     """Test basic functionality and verify safe_percentile calls."""
-    mock_safe_percentile = mocker.patch('ds_utils.preprocess.safe_percentile', wraps=safe_percentile)
+    mock_safe_percentile = mocker.patch("ds_utils.preprocess.safe_percentile", wraps=safe_percentile)
 
-    result = extract_statistics_dataframe_per_label(sample_df, 'value', 'category')
+    result = extract_statistics_dataframe_per_label(sample_df, "value", "category")
 
     # Check if all expected columns are present
     expected_columns = [
-        'count', 'null_count', 'mean', 'min', '1_percentile', '5_percentile',
-        '25_percentile', 'median', '75_percentile', '95_percentile', '99_percentile', 'max'
+        "count",
+        "null_count",
+        "mean",
+        "min",
+        "1_percentile",
+        "5_percentile",
+        "25_percentile",
+        "median",
+        "75_percentile",
+        "95_percentile",
+        "99_percentile",
+        "max",
     ]
     assert all(col in result.columns for col in expected_columns)
 
@@ -262,17 +325,24 @@ def test_extract_statistics_dataframe_per_label_basic_functionality(sample_df, m
 
     # Verify some specific calls
     expected_series_a = pd.Series([1.0, 2.0, 3.0])
-    assert assert_series_called_with(mock_safe_percentile.call_args_list,
-                                     expected_series_a, 1)  # Category A, 1st percentile
-    assert assert_series_called_with(mock_safe_percentile.call_args_list,
-                                     expected_series_a, 99)  # Category A, 99th percentile
+    assert assert_series_called_with(
+        mock_safe_percentile.call_args_list, expected_series_a, 1
+    )  # Category A, 1st percentile
+    assert assert_series_called_with(
+        mock_safe_percentile.call_args_list, expected_series_a, 99
+    )  # Category A, 99th percentile
 
 
-@pytest.mark.parametrize("feature_name, label_name, exception, message", [
-    ('invalid_col', 'category', KeyError, "Feature column 'invalid_col' not found"),
-    ('value', 'invalid_col', KeyError, "Label column 'invalid_col' not found"),
-    ('text_col', 'category', TypeError, "Feature column 'text_col' must be numeric")
-], ids=["test_invalid_feature_name", "test_invalid_label_name", "test_non_numeric_feature"])
+@pytest.mark.parametrize(
+    ("feature_name", "label_name", "exception", "message"),
+    [
+        ("invalid_col", "category", KeyError, "Feature column 'invalid_col' not found"),
+        ("value", "invalid_col", KeyError, "Label column 'invalid_col' not found"),
+        ("text_col", "category", TypeError, "Feature column 'text_col' must be numeric"),
+    ],
+    ids=["test_invalid_feature_name", "test_invalid_label_name", "test_non_numeric_feature"],
+)
 def test_extract_statistics_dataframe_per_label_exceptions(sample_df, feature_name, label_name, exception, message):
+    """Test exceptions for extract_statistics_dataframe_per_label."""
     with pytest.raises(exception, match=message):
         extract_statistics_dataframe_per_label(sample_df, feature_name, label_name)

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -1,3 +1,5 @@
+"""Tests for string manipulation utility functions."""
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -7,56 +9,63 @@ from sklearn.feature_extraction.text import CountVectorizer
 from ds_utils.strings import append_tags_to_frame, extract_significant_terms_from_subset
 
 
-@pytest.mark.parametrize("x_train, x_test, expected_train, expected_test", [
-    (
-            pd.DataFrame([
-                {"article_name": "1", "article_tags": "ds,ml,dl"},
-                {"article_name": "2", "article_tags": "ds,ml"}
-            ]),
-            pd.DataFrame([
-                {"article_name": "3", "article_tags": "ds,ml,py"}
-            ]),
-            pd.DataFrame([
-                {"article_name": "1", "tag_ds": 1, "tag_ml": 1, "tag_dl": 1},
-                {"article_name": "2", "tag_ds": 1, "tag_ml": 1, "tag_dl": 0}
-            ], columns=["article_name", "tag_dl", "tag_ds", "tag_ml"]),
-            pd.DataFrame([
-                {"article_name": "3", "tag_ds": 1, "tag_ml": 1, "tag_dl": 0}
-            ], columns=["article_name", "tag_dl", "tag_ds", "tag_ml"])
-    ),
-    (
-            pd.DataFrame([
-                {"article_name": "1", "article_tags": ""},
-                {"article_name": "2", "article_tags": "python"}
-            ]),
-            pd.DataFrame([
-                {"article_name": "3", "article_tags": "java,python"}
-            ]),
-            pd.DataFrame([
-                {"article_name": "1", "tag_python": 0},
-                {"article_name": "2", "tag_python": 1}
-            ], columns=["article_name", "tag_python"]),
-            pd.DataFrame([
-                {"article_name": "3", "tag_python": 1}
-            ], columns=["article_name", "tag_python"])
-    )
-], ids=["small tags", "regular tags"])
+@pytest.mark.parametrize(
+    ("x_train", "x_test", "expected_train", "expected_test"),
+    [
+        (
+            pd.DataFrame(
+                [{"article_name": "1", "article_tags": "ds,ml,dl"}, {"article_name": "2", "article_tags": "ds,ml"}]
+            ),
+            pd.DataFrame([{"article_name": "3", "article_tags": "ds,ml,py"}]),
+            pd.DataFrame(
+                [
+                    {"article_name": "1", "tag_ds": 1, "tag_ml": 1, "tag_dl": 1},
+                    {"article_name": "2", "tag_ds": 1, "tag_ml": 1, "tag_dl": 0},
+                ],
+                columns=["article_name", "tag_dl", "tag_ds", "tag_ml"],
+            ),
+            pd.DataFrame(
+                [{"article_name": "3", "tag_ds": 1, "tag_ml": 1, "tag_dl": 0}],
+                columns=["article_name", "tag_dl", "tag_ds", "tag_ml"],
+            ),
+        ),
+        (
+            pd.DataFrame([{"article_name": "1", "article_tags": ""}, {"article_name": "2", "article_tags": "python"}]),
+            pd.DataFrame([{"article_name": "3", "article_tags": "java,python"}]),
+            pd.DataFrame(
+                [{"article_name": "1", "tag_python": 0}, {"article_name": "2", "tag_python": 1}],
+                columns=["article_name", "tag_python"],
+            ),
+            pd.DataFrame([{"article_name": "3", "tag_python": 1}], columns=["article_name", "tag_python"]),
+        ),
+    ],
+    ids=["small tags", "regular tags"],
+)
 def test_append_tags_to_frame(x_train, x_test, expected_train, expected_test):
+    """Test appending tags to DataFrame for various scenarios."""
     x_train_with_tags, x_test_with_tags = append_tags_to_frame(x_train, x_test, "article_tags", "tag_")
     pd.testing.assert_frame_equal(expected_train, x_train_with_tags, check_like=True)
     pd.testing.assert_frame_equal(expected_test, x_test_with_tags, check_like=True)
 
 
-@pytest.mark.parametrize("x_train, x_test",
-                         [(pd.DataFrame(columns=["article_name", "article_tags"]), pd.DataFrame([
-                             {"article_name": "3", "article_tags": "ds,ml,py"}
-                         ])),
-                          (pd.DataFrame([
-                              {"article_name": "1", "article_tags": "ds,ml,dl"},
-                              {"article_name": "2", "article_tags": "ds,ml"}
-                          ]), pd.DataFrame(columns=["article_name", "article_tags"]))],
-                         ids=["empty_train", "empty_test"])
+@pytest.mark.parametrize(
+    ("x_train", "x_test"),
+    [
+        (
+            pd.DataFrame(columns=["article_name", "article_tags"]),
+            pd.DataFrame([{"article_name": "3", "article_tags": "ds,ml,py"}]),
+        ),
+        (
+            pd.DataFrame(
+                [{"article_name": "1", "article_tags": "ds,ml,dl"}, {"article_name": "2", "article_tags": "ds,ml"}]
+            ),
+            pd.DataFrame(columns=["article_name", "article_tags"]),
+        ),
+    ],
+    ids=["empty_train", "empty_test"],
+)
 def test_append_tags_to_frame_empty_dataframes(request, x_train, x_test):
+    """Test appending tags when one of the input DataFrames is empty."""
     x_train_with_tags, x_test_with_tags = append_tags_to_frame(x_train, x_test, "article_tags", "tag_")
     if request.node.callspec.id == "empty_train":
         assert x_train_with_tags.empty
@@ -64,6 +73,7 @@ def test_append_tags_to_frame_empty_dataframes(request, x_train, x_test):
 
 
 def test_append_tags_to_frame_missing_column():
+    """Test append_tags_to_frame raises KeyError if specified field_name is missing."""
     x_train = pd.DataFrame([{"article_name": "1"}])
     x_test = pd.DataFrame([{"article_name": "2"}])
     with pytest.raises(KeyError):
@@ -71,13 +81,16 @@ def test_append_tags_to_frame_missing_column():
 
 
 def test_append_tags_to_frame_custom_tokenizer():
+    """Test append_tags_to_frame with a custom tokenizer."""
+
     def custom_tokenizer(text):
-        return text.split('|')
+        return text.split("|")
 
     x_train = pd.DataFrame([{"article_name": "1", "article_tags": "ds|ml|dl"}])
     x_test = pd.DataFrame([{"article_name": "2", "article_tags": "py|ml"}])
-    x_train_with_tags, x_test_with_tags = append_tags_to_frame(x_train, x_test, "article_tags", "tag_",
-                                                               tokenizer=custom_tokenizer)
+    x_train_with_tags, x_test_with_tags = append_tags_to_frame(
+        x_train, x_test, "article_tags", "tag_", tokenizer=custom_tokenizer
+    )
 
     expected_train = pd.DataFrame([{"article_name": "1", "tag_ds": 1, "tag_ml": 1, "tag_dl": 1}])
     expected_test = pd.DataFrame([{"article_name": "2", "tag_ds": 0, "tag_ml": 1, "tag_dl": 0}])
@@ -87,42 +100,52 @@ def test_append_tags_to_frame_custom_tokenizer():
 
 
 def test_append_tags_to_frame_with_nan_values():
+    """Test append_tags_to_frame when 'article_tags' column contains NaN values."""
     x_train = pd.DataFrame(
-        [{"article_name": "1", "article_tags": "ds,ml"}, {"article_name": "2", "article_tags": np.nan}])
+        [{"article_name": "1", "article_tags": "ds,ml"}, {"article_name": "2", "article_tags": np.nan}]
+    )
     x_test = pd.DataFrame([{"article_name": "3", "article_tags": "py"}])
 
     x_train_with_tags, x_test_with_tags = append_tags_to_frame(x_train, x_test, "article_tags", "tag_")
 
-    expected_train = pd.DataFrame([
-        {"article_name": "1", "tag_ds": 1, "tag_ml": 1},
-        {"article_name": "2", "tag_ds": 0, "tag_ml": 0}
-    ])
+    expected_train = pd.DataFrame(
+        [{"article_name": "1", "tag_ds": 1, "tag_ml": 1}, {"article_name": "2", "tag_ds": 0, "tag_ml": 0}]
+    )
     expected_test = pd.DataFrame([{"article_name": "3", "tag_ds": 0, "tag_ml": 0}])
 
     pd.testing.assert_frame_equal(expected_train, x_train_with_tags, check_like=True)
     pd.testing.assert_frame_equal(expected_test, x_test_with_tags, check_like=True)
 
 
-@pytest.mark.parametrize("corpus, subset_indices, expected", [
-    (
-            ['This is the first document.', 'This document is the second document.', 'And this is the third one.',
-             'Is this the first document?'],
+@pytest.mark.parametrize(
+    ("corpus", "subset_indices", "expected"),
+    [
+        (
+            [
+                "This is the first document.",
+                "This document is the second document.",
+                "And this is the third one.",
+                "Is this the first document?",
+            ],
             [2, 3],
             pd.Series(
                 [1.0, 1.0, 1.0, 0.6666666666666666, 0.6666666666666666, 0.6666666666666666, 0.5, 0.25, 0.0],
-                index=['and', 'one', 'third', 'is', 'the', 'this', 'first', 'document', 'second']
-            )
-    ),
-    (
-            ['Python is great', 'Java is also good', 'Python and Java are programming languages'],
+                index=["and", "one", "third", "is", "the", "this", "first", "document", "second"],
+            ),
+        ),
+        (
+            ["Python is great", "Java is also good", "Python and Java are programming languages"],
             [2],
             pd.Series(
                 [1.0, 1.0, 1.0, 1.0, 0.5, 0.5, 0.0, 0.0, 0.0, 0.0],
-                index=['and', 'are', 'languages', 'programming', 'java', 'python', 'also', 'good', 'great', 'is']
-            )
-    )
-], ids=["simple document", "natural documents"])
+                index=["and", "are", "languages", "programming", "java", "python", "also", "good", "great", "is"],
+            ),
+        ),
+    ],
+    ids=["simple document", "natural documents"],
+)
 def test_significant_terms(corpus, subset_indices, expected):
+    """Test extraction of significant terms from a subset of documents."""
     data_frame = pd.DataFrame(corpus, columns=["content"])
     subset_data_frame = data_frame.iloc[subset_indices]
     terms = extract_significant_terms_from_subset(data_frame, subset_data_frame, "content")
@@ -130,6 +153,7 @@ def test_significant_terms(corpus, subset_indices, expected):
 
 
 def test_significant_terms_empty_dataframe():
+    """Test significant terms extraction with empty DataFrames."""
     data_frame = pd.DataFrame(columns=["content"])
     subset_data_frame = pd.DataFrame(columns=["content"])
     terms = extract_significant_terms_from_subset(data_frame, subset_data_frame, "content")
@@ -137,7 +161,8 @@ def test_significant_terms_empty_dataframe():
 
 
 def test_significant_terms_custom_vectorizer(mocker):
-    corpus = ['This is the first document.', 'This document is the second document.']
+    """Test significant terms extraction with a custom CountVectorizer."""
+    corpus = ["This is the first document.", "This document is the second document."]
     data_frame = pd.DataFrame(corpus, columns=["content"])
     subset_data_frame = data_frame.iloc[1:]
 
@@ -145,13 +170,14 @@ def test_significant_terms_custom_vectorizer(mocker):
     fit_transform_result = mocker.Mock(spec=csr_array)
     fit_transform_result.toarray.return_value = np.array([[1, 0], [2, 1]])
     custom_vectorizer.fit_transform.return_value = fit_transform_result
-    custom_vectorizer.get_feature_names_out.return_value = np.array(['document', 'second'])
+    custom_vectorizer.get_feature_names_out.return_value = np.array(["document", "second"])
     transform_result = mocker.Mock(spec=csr_array)
     transform_result.toarray.return_value = np.array([[2, 1]])
     custom_vectorizer.transform.return_value = transform_result
 
-    terms = extract_significant_terms_from_subset(data_frame, subset_data_frame, "content",
-                                                  vectorizer=custom_vectorizer)
+    terms = extract_significant_terms_from_subset(
+        data_frame, subset_data_frame, "content", vectorizer=custom_vectorizer
+    )
 
-    expected = pd.Series([1.0, 1.0], index=['document', 'second'])
+    expected = pd.Series([1.0, 1.0], index=["document", "second"])
     pd.testing.assert_series_equal(expected, terms, check_like=True)

--- a/tests/test_unsupervised.py
+++ b/tests/test_unsupervised.py
@@ -1,3 +1,5 @@
+"""Tests for unsupervised learning utility functions."""
+
 from pathlib import Path
 
 import numpy as np
@@ -10,37 +12,195 @@ from ds_utils.unsupervised import (
     plot_cluster_cardinality,
     plot_cluster_magnitude,
     plot_magnitude_vs_cardinality,
-    plot_loss_vs_cluster_number
+    plot_loss_vs_cluster_number,
 )
 
 BASELINE_DIR = Path(__file__).parent / "baseline_images" / "test_unsupervised"
 
 
-@pytest.fixture()
+@pytest.fixture
 def iris_data():
+    """Load and return Iris dataset components for testing."""
     iris_x = pd.read_csv(Path(__file__).parents[0].joinpath("resources").joinpath("iris_x_full.csv"))
     labels = np.asarray(
-        [1, 6, 6, 6, 1, 1, 6, 1, 6, 6, 1, 6, 6, 6, 1, 1, 1, 1, 1, 1, 1, 1, 6, 1, 6, 6, 1, 1, 1, 6, 6, 1, 1, 1, 6,
-         6, 1, 1, 6, 1, 1, 6, 6, 1, 1, 6, 1, 6, 1, 6, 0, 0, 0, 3, 0, 3, 0, 5, 0, 3, 5, 3, 3, 0, 3, 0, 3, 3, 4, 3,
-         4, 3, 4, 0, 0, 0, 0, 0, 0, 3, 3, 3, 3, 4, 3, 0, 0, 0, 3, 3, 3, 0, 3, 5, 3, 3, 3, 0, 5, 3, 7, 4, 2, 7, 7,
-         2, 3, 2, 7, 2, 7, 4, 7, 4, 4, 7, 7, 2, 2, 4, 7, 4, 2, 4, 7, 2, 4, 4, 7, 2, 2, 2, 7, 4, 4, 2, 7, 7, 4, 7,
-         7, 7, 4, 7, 7, 7, 4, 7, 7, 4])
-    cluster_centers = np.asarray([
-        [6.442105263157895223e+00, 2.978947368421052566e+00, 4.594736842105263008e+00, 1.431578947368421062e+00],
-        [5.242857142857142883e+00, 3.667857142857142705e+00, 1.499999999999999556e+00, 2.821428571428574728e-01],
-        [7.474999999999999645e+00, 3.125000000000000000e+00, 6.299999999999999822e+00, 2.049999999999999822e+00],
-        [5.620833333333333570e+00, 2.691666666666666430e+00, 4.075000000000000178e+00, 1.262499999999999956e+00],
-        [6.036842105263158231e+00, 2.705263157894736814e+00, 5.000000000000000000e+00, 1.778947368421052611e+00],
-        [5.000000000000000000e+00, 2.299999999999999822e+00, 3.274999999999999911e+00, 1.024999999999999911e+00],
-        [4.704545454545455030e+00, 3.122727272727272574e+00, 1.413636363636363136e+00, 2.000000000000001776e-01],
-        [6.568181818181818343e+00, 3.086363636363636420e+00, 5.536363636363637042e+00, 2.163636363636363580e+00]])
+        [
+            1,
+            6,
+            6,
+            6,
+            1,
+            1,
+            6,
+            1,
+            6,
+            6,
+            1,
+            6,
+            6,
+            6,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            6,
+            1,
+            6,
+            6,
+            1,
+            1,
+            1,
+            6,
+            6,
+            1,
+            1,
+            1,
+            6,
+            6,
+            1,
+            1,
+            6,
+            1,
+            1,
+            6,
+            6,
+            1,
+            1,
+            6,
+            1,
+            6,
+            1,
+            6,
+            0,
+            0,
+            0,
+            3,
+            0,
+            3,
+            0,
+            5,
+            0,
+            3,
+            5,
+            3,
+            3,
+            0,
+            3,
+            0,
+            3,
+            3,
+            4,
+            3,
+            4,
+            3,
+            4,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            3,
+            3,
+            3,
+            3,
+            4,
+            3,
+            0,
+            0,
+            0,
+            3,
+            3,
+            3,
+            0,
+            3,
+            5,
+            3,
+            3,
+            3,
+            0,
+            5,
+            3,
+            7,
+            4,
+            2,
+            7,
+            7,
+            2,
+            3,
+            2,
+            7,
+            2,
+            7,
+            4,
+            7,
+            4,
+            4,
+            7,
+            7,
+            2,
+            2,
+            4,
+            7,
+            4,
+            2,
+            4,
+            7,
+            2,
+            4,
+            4,
+            7,
+            2,
+            2,
+            2,
+            7,
+            4,
+            4,
+            2,
+            7,
+            7,
+            4,
+            7,
+            7,
+            7,
+            4,
+            7,
+            7,
+            7,
+            4,
+            7,
+            7,
+            4,
+        ]
+    )
+    cluster_centers = np.asarray(
+        [
+            [6.442105263157895223e00, 2.978947368421052566e00, 4.594736842105263008e00, 1.431578947368421062e00],
+            [5.242857142857142883e00, 3.667857142857142705e00, 1.499999999999999556e00, 2.821428571428574728e-01],
+            [7.474999999999999645e00, 3.125000000000000000e00, 6.299999999999999822e00, 2.049999999999999822e00],
+            [5.620833333333333570e00, 2.691666666666666430e00, 4.075000000000000178e00, 1.262499999999999956e00],
+            [6.036842105263158231e00, 2.705263157894736814e00, 5.000000000000000000e00, 1.778947368421052611e00],
+            [5.000000000000000000e00, 2.299999999999999822e00, 3.274999999999999911e00, 1.024999999999999911e00],
+            [4.704545454545455030e00, 3.122727272727272574e00, 1.413636363636363136e00, 2.000000000000001776e-01],
+            [6.568181818181818343e00, 3.086363636363636420e00, 5.536363636363637042e00, 2.163636363636363580e00],
+        ]
+    )
     return iris_x, labels, cluster_centers
 
 
 @pytest.fixture
 def distance_wrapper_plot_magnitude_vs_cardinality(mocker):
-    with Path(__file__).parents[0].joinpath("resources").joinpath(
-            "euclidean_distances_plot_magnitude_vs_cardinality.txt").open("r") as file:
+    """Create a mock distance function that returns preloaded distances."""
+    with (
+        Path(__file__)
+        .parents[0]
+        .joinpath("resources")
+        .joinpath("euclidean_distances_plot_magnitude_vs_cardinality.txt")
+        .open("r") as file
+    ):
         loaded_distances = [float(line.strip()) for line in file]
 
     mock_distance = mocker.Mock(side_effect=loaded_distances)
@@ -54,6 +214,7 @@ def distance_wrapper_plot_magnitude_vs_cardinality(mocker):
 
 @pytest.fixture(autouse=True)
 def setup_teardown():
+    """Set up and tear down for each test in this module."""
     yield
     plt.cla()
     plt.close(plt.gcf())
@@ -61,6 +222,7 @@ def setup_teardown():
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_cluster_cardinality(iris_data):
+    """Test plotting cluster cardinality."""
     _, labels, _ = iris_data
     plot_cluster_cardinality(np.asarray(labels))
     return plt.gcf()
@@ -68,6 +230,7 @@ def test_cluster_cardinality(iris_data):
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_cluster_cardinality_exist_ax(iris_data):
+    """Test plotting cluster cardinality on an existing Axes object."""
     fig, ax = plt.subplots()
     ax.set_title("My ax")
 
@@ -78,12 +241,14 @@ def test_cluster_cardinality_exist_ax(iris_data):
 
 
 def test_cluster_cardinality_empty_labels():
+    """Test plot_cluster_cardinality raises ValueError for empty labels."""
     with pytest.raises(ValueError, match="Labels array is empty."):
         plot_cluster_cardinality(np.array([]))
 
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_plot_cluster_magnitude(iris_data, distance_wrapper_plot_magnitude_vs_cardinality):
+    """Test plotting cluster magnitude."""
     iris_x, labels, cluster_centers = iris_data
 
     plot_cluster_magnitude(iris_x.values, labels, cluster_centers, distance_wrapper_plot_magnitude_vs_cardinality)
@@ -92,29 +257,34 @@ def test_plot_cluster_magnitude(iris_data, distance_wrapper_plot_magnitude_vs_ca
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_plot_cluster_magnitude_exist_ax(iris_data, distance_wrapper_plot_magnitude_vs_cardinality):
+    """Test plotting cluster magnitude on an existing Axes object."""
     fig, ax = plt.subplots()
     ax.set_title("My ax")
 
     iris_x, labels, cluster_centers = iris_data
-    plot_cluster_magnitude(iris_x.values, labels, cluster_centers, distance_wrapper_plot_magnitude_vs_cardinality,
-                           ax=ax)
+    plot_cluster_magnitude(
+        iris_x.values, labels, cluster_centers, distance_wrapper_plot_magnitude_vs_cardinality, ax=ax
+    )
     assert ax.get_title() == "My ax"
     return fig
 
 
 def test_cluster_magnitude_inconsistent_shapes(mocker, iris_data):
+    """Test plot_cluster_magnitude with inconsistent X and labels shapes."""
     iris_x, labels, cluster_centers = iris_data
     with pytest.raises(ValueError, match="X and labels must have the same length."):
         plot_cluster_magnitude(iris_x.values[:-1], labels, cluster_centers, mocker.Mock())
 
 
 def test_cluster_magnitude_invalid_distance_function(mocker, iris_data):
+    """Test plot_cluster_magnitude with an invalid distance_function."""
     iris_x, labels, cluster_centers = iris_data
     with pytest.raises(ValueError, match="Invalid distance_function provided."):
         plot_cluster_magnitude(iris_x.values, labels, cluster_centers, mocker.Mock(side_effect=TypeError))
 
 
 def test_cluster_magnitude_invalid_cluster_number_vs_labels(mocker, iris_data):
+    """Test plot_cluster_magnitude with mismatch between cluster_centers and labels."""
     iris_x, labels, cluster_centers = iris_data
     with pytest.raises(ValueError, match="Number of cluster centers must match the number of unique labels."):
         plot_cluster_magnitude(np.array([1]), np.array([1]), cluster_centers, mocker.Mock())
@@ -122,37 +292,44 @@ def test_cluster_magnitude_invalid_cluster_number_vs_labels(mocker, iris_data):
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_plot_magnitude_vs_cardinality(iris_data, distance_wrapper_plot_magnitude_vs_cardinality):
+    """Test plotting magnitude vs. cardinality."""
     iris_x, labels, cluster_centers = iris_data
-    plot_magnitude_vs_cardinality(iris_x.values, labels, cluster_centers,
-                                  distance_wrapper_plot_magnitude_vs_cardinality)
+    plot_magnitude_vs_cardinality(
+        iris_x.values, labels, cluster_centers, distance_wrapper_plot_magnitude_vs_cardinality
+    )
     return plt.gcf()
 
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_plot_magnitude_vs_cardinality_exist_ax(iris_data, distance_wrapper_plot_magnitude_vs_cardinality):
+    """Test plotting magnitude vs. cardinality on an existing Axes object."""
     fig, ax = plt.subplots()
     ax.set_title("My ax")
 
     iris_x, labels, cluster_centers = iris_data
-    plot_magnitude_vs_cardinality(iris_x.values, labels, cluster_centers,
-                                  distance_wrapper_plot_magnitude_vs_cardinality, ax=ax)
+    plot_magnitude_vs_cardinality(
+        iris_x.values, labels, cluster_centers, distance_wrapper_plot_magnitude_vs_cardinality, ax=ax
+    )
     assert ax.get_title() == "My ax"
     return fig
 
 
 def test_plot_magnitude_vs_cardinality_inconsistent_shapes(mocker, iris_data):
+    """Test plot_magnitude_vs_cardinality with inconsistent X and labels shapes."""
     iris_x, labels, cluster_centers = iris_data
     with pytest.raises(ValueError, match="X and labels must have the same length."):
         plot_magnitude_vs_cardinality(iris_x.values[:-1], labels, cluster_centers, mocker.Mock())
 
 
 def test_magnitude_vs_cardinality_inconsistent_centers(mocker, iris_data):
+    """Test plot_magnitude_vs_cardinality with inconsistent cluster_centers."""
     iris_x, labels, cluster_centers = iris_data
     with pytest.raises(ValueError, match="Number of cluster centers must match the number of unique labels."):
         plot_magnitude_vs_cardinality(iris_x.values, labels, cluster_centers[:-1], mocker.Mock())
 
 
 def test_magnitude_vs_cardinality_invalid_distance_function(mocker, iris_data):
+    """Test plot_magnitude_vs_cardinality with an invalid distance_function."""
     iris_x, labels, cluster_centers = iris_data
     with pytest.raises(ValueError, match="Invalid distance_function provided."):
         plot_magnitude_vs_cardinality(iris_x.values, labels, cluster_centers, mocker.Mock(side_effect=TypeError))
@@ -160,6 +337,7 @@ def test_magnitude_vs_cardinality_invalid_distance_function(mocker, iris_data):
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_plot_loss_vs_cluster_number(iris_data):
+    """Test plotting loss vs. number of clusters."""
     iris_x, _, _ = iris_data
     plot_loss_vs_cluster_number(iris_x.values, 3, 20, euclidean)
     return plt.gcf()
@@ -167,8 +345,9 @@ def test_plot_loss_vs_cluster_number(iris_data):
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_plot_loss_vs_cluster_number_exist_ax(iris_data):
+    """Test plotting loss vs. number of clusters on an existing Axes object."""
     fig, ax = plt.subplots()
-    ax.set_facecolor('tab:red')
+    ax.set_facecolor("tab:red")
 
     iris_x, _, _ = iris_data
     plot_loss_vs_cluster_number(iris_x.values, 3, 20, euclidean, ax=ax)
@@ -177,20 +356,29 @@ def test_plot_loss_vs_cluster_number_exist_ax(iris_data):
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_plot_loss_vs_cluster_number_given_parameters(iris_data):
+    """Test plotting loss vs. number of clusters with specific algorithm parameters."""
     iris_x, _, _ = iris_data
-    plot_loss_vs_cluster_number(iris_x.values, 3, 20, euclidean,
-                                algorithm_parameters={"random_state": 42, "algorithm": "lloyd", "n_clusters": 3})
+    plot_loss_vs_cluster_number(
+        iris_x.values,
+        3,
+        20,
+        euclidean,
+        algorithm_parameters={"random_state": 42, "algorithm": "lloyd", "n_clusters": 3},
+    )
     return plt.gcf()
 
 
 def test_loss_vs_cluster_number_invalid_k_range(mocker, iris_data):
+    """Test plot_loss_vs_cluster_number with an invalid k_min > k_max."""
     iris_x, _, _ = iris_data
     with pytest.raises(ValueError, match="k_min must be less than or equal to k_max."):
         plot_loss_vs_cluster_number(iris_x.values, 10, 5, mocker.Mock())
 
 
 def test_loss_vs_cluster_number_invalid_algorithm_parameters(mocker, iris_data):
+    """Test plot_loss_vs_cluster_number with invalid algorithm parameters."""
     iris_x, _, _ = iris_data
     with pytest.raises(ValueError, match="No valid results were obtained. Check your input data and parameters."):
-        plot_loss_vs_cluster_number(iris_x.values, 3, 20, mocker.Mock(),
-                                    algorithm_parameters={"invalid_param": "value"})
+        plot_loss_vs_cluster_number(
+            iris_x.values, 3, 20, mocker.Mock(), algorithm_parameters={"invalid_param": "value"}
+        )

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,5 +1,8 @@
+"""Tests for the package version."""
+
 import ds_utils
 
 
 def test_version():
+    """Test that the package version is correct."""
     assert ds_utils.__version__ == "1.8.1"

--- a/tests/test_xai.py
+++ b/tests/test_xai.py
@@ -14,6 +14,7 @@ BASELINE_DIR = Path(__file__).parent / "baseline_images" / "test_xai"
 
 @pytest.fixture
 def decision_tree_generate_decision_paths(mocker):
+    """Fixture for a mocked decision tree for testing generate_decision_paths."""
     mock_tree = mocker.Mock()
     mock_tree.tree_.feature = np.array([3, -2, 3, 2, -2, -2, 2, -2, -2])
     mock_tree.tree_.threshold = np.array([0.80000001, -2.0, 1.75, 4.95000005, -2.0, -2.0, 4.85000014, -2.0, -2.0])
@@ -38,6 +39,7 @@ def decision_tree_generate_decision_paths(mocker):
 
 @pytest.fixture
 def decision_tree_draw_tree(mocker):
+    """Fixture for a mocked decision tree for testing draw_tree."""
     mock = mocker.Mock()
     mock.tree_.node_count = 17
     mock.tree_.children_left = np.array([1, -1, 3, 4, 5, -1, -1, 8, -1, 10, -1, -1, 13, 14, -1, -1, -1])
@@ -147,8 +149,6 @@ def decision_tree_draw_tree(mocker):
     # Add the __sklearn_tags__ method that returns the mock_tags object
     mock.__sklearn_tags__ = mocker.Mock(return_value=mock_tags)
 
-    # Add some fitted attributes to make the estimator appear fitted
-    # mock.feature_importances_ = np.random.Generator(4)
     mock.n_features_ = 4
 
     return mock
@@ -156,6 +156,7 @@ def decision_tree_draw_tree(mocker):
 
 @pytest.fixture
 def importance():
+    """Fixture for sample feature importances."""
     return [
         0.047304175084187376,
         0.011129476233187116,
@@ -246,6 +247,7 @@ def importance():
 
 @pytest.fixture
 def features():
+    """Fixture for sample feature names."""
     return [
         "x1",
         "x2",
@@ -336,13 +338,14 @@ def features():
 
 @pytest.fixture(autouse=True)
 def setup_teardown():
+    """Set up and tear down for each test in this module."""
     yield
     plt.cla()
     plt.close(plt.gcf())
 
 
 @pytest.mark.parametrize(
-    "tree_name, expected_name",
+    ("tree_name", "expected_name"),
     [
         ("iris_tree", "def iris_tree(petal width (cm), petal length (cm)):"),
         (None, "def tree(petal width (cm), petal length (cm)):"),
@@ -350,6 +353,7 @@ def setup_teardown():
     ids=["default", "no_tree_name"],
 )
 def test_print_decision_paths(tree_name, expected_name, decision_tree_generate_decision_paths):
+    """Test generation of decision paths from a tree."""
     with pytest.warns(DeprecationWarning, match="This module is deprecated. Use sklearn.tree.export_text instead"):
         result = generate_decision_paths(
             decision_tree_generate_decision_paths,
@@ -406,6 +410,7 @@ def test_print_decision_paths(tree_name, expected_name, decision_tree_generate_d
 
 
 def test_print_decision_paths_no_feature_names(decision_tree_generate_decision_paths):
+    """Test decision path generation when feature_names are not provided."""
     with pytest.warns(DeprecationWarning, match="This module is deprecated. Use sklearn.tree.export_text instead"):
         result = generate_decision_paths(
             decision_tree_generate_decision_paths, None, ["setosa", "versicolor", "virginica"], "iris_tree", "  "
@@ -456,6 +461,7 @@ def test_print_decision_paths_no_feature_names(decision_tree_generate_decision_p
 
 
 def test_print_decision_paths_no_class_names(decision_tree_generate_decision_paths):
+    """Test decision path generation when class_names are not provided."""
     with pytest.warns(DeprecationWarning, match="This module is deprecated. Use sklearn.tree.export_text instead"):
         result = generate_decision_paths(
             decision_tree_generate_decision_paths,
@@ -511,6 +517,7 @@ def test_print_decision_paths_no_class_names(decision_tree_generate_decision_pat
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR, tolerance=53)
 def test_draw_tree(decision_tree_draw_tree):
+    """Test drawing a decision tree."""
     with pytest.warns(DeprecationWarning, match="This module is deprecated. Use sklearn.tree.plot_tree instead"):
         draw_tree(
             decision_tree_draw_tree,
@@ -522,6 +529,7 @@ def test_draw_tree(decision_tree_draw_tree):
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR, tolerance=54)
 def test_draw_tree_exists_ax(decision_tree_draw_tree):
+    """Test drawing a decision tree on an existing Axes object."""
     fig, ax = plt.subplots()
     ax.set_title("My ax")
     with pytest.warns(DeprecationWarning, match="This module is deprecated. Use sklearn.tree.plot_tree instead"):
@@ -538,6 +546,7 @@ def test_draw_tree_exists_ax(decision_tree_draw_tree):
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR, tolerance=11)
 def test_draw_dot_data():
+    """Test drawing a graph from DOT data."""
     dot_data = (
         "digraph D{\n"
         "\tA [shape=diamond]\n"
@@ -557,6 +566,7 @@ def test_draw_dot_data():
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR, tolerance=11)
 def test_draw_dot_data_exist_ax():
+    """Test drawing a graph from DOT data on an existing Axes object."""
     dot_data = (
         "digraph D{\n"
         "\tA [shape=diamond]\n"
@@ -579,11 +589,13 @@ def test_draw_dot_data_exist_ax():
 
 
 def test_draw_dot_data_empty_input():
+    """Test draw_dot_data raises ValueError for empty input string."""
     with pytest.raises(ValueError, match="dot_data must not be empty"):
         draw_dot_data("")
 
 
 def test_draw_dot_data_invalid_input(mocker):
+    """Test draw_dot_data raises ValueError for invalid DOT data."""
     mock_pydotplus = mocker.patch("ds_utils.xai.pydotplus")
     mock_pydotplus.graph_from_dot_data.side_effect = Exception("Invalid dot data")
 
@@ -593,6 +605,7 @@ def test_draw_dot_data_invalid_input(mocker):
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_plot_features_importance(importance, features):
+    """Test plotting feature importance."""
     plot_features_importance(features, importance)
 
     figure = plt.gcf()
@@ -602,6 +615,7 @@ def test_plot_features_importance(importance, features):
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR)
 def test_plot_features_importance_exists_ax(importance, features):
+    """Test plotting feature importance on an existing Axes object."""
     fig, ax = plt.subplots()
 
     ax.set_title("My ax")

--- a/tests/test_xai.py
+++ b/tests/test_xai.py
@@ -1,3 +1,5 @@
+"""Tests for Explainable AI (XAI) utility functions."""
+
 import os
 from pathlib import Path
 
@@ -5,32 +7,36 @@ import numpy as np
 import pytest
 from matplotlib import pyplot as plt
 
-from ds_utils.xai import (
-    generate_decision_paths,
-    draw_tree,
-    draw_dot_data,
-    plot_features_importance
-)
+from ds_utils.xai import generate_decision_paths, draw_tree, draw_dot_data, plot_features_importance
 
 BASELINE_DIR = Path(__file__).parent / "baseline_images" / "test_xai"
 
 
-@pytest.fixture()
+@pytest.fixture
 def decision_tree_generate_decision_paths(mocker):
     mock_tree = mocker.Mock()
     mock_tree.tree_.feature = np.array([3, -2, 3, 2, -2, -2, 2, -2, -2])
-    mock_tree.tree_.threshold = np.array([0.80000001, -2., 1.75, 4.95000005, -2., -2., 4.85000014, -2., -2.])
+    mock_tree.tree_.threshold = np.array([0.80000001, -2.0, 1.75, 4.95000005, -2.0, -2.0, 4.85000014, -2.0, -2.0])
     mock_tree.tree_.children_left = np.array([1, -1, 3, 4, -1, -1, 7, -1, -1])
     mock_tree.tree_.children_right = np.array([2, -1, 6, 5, -1, -1, 8, -1, -1])
     mock_tree.tree_.value = np.array(
-        [[[0.33333333, 0.33333333, 0.33333333]], [[1., 0., 0.]], [[0., 0.5, 0.5]], [[0., 0.90740741, 0.09259259]],
-         [[0., 0.97916667, 0.02083333]], [[0., 0.33333333, 0.66666667]], [[0., 0.02173913, 0.97826087]],
-         [[0., 0.33333333, 0.66666667]], [[0., 0., 1.]]])
+        [
+            [[0.33333333, 0.33333333, 0.33333333]],
+            [[1.0, 0.0, 0.0]],
+            [[0.0, 0.5, 0.5]],
+            [[0.0, 0.90740741, 0.09259259]],
+            [[0.0, 0.97916667, 0.02083333]],
+            [[0.0, 0.33333333, 0.66666667]],
+            [[0.0, 0.02173913, 0.97826087]],
+            [[0.0, 0.33333333, 0.66666667]],
+            [[0.0, 0.0, 1.0]],
+        ]
+    )
     mock_tree.n_features_in_ = 4
     return mock_tree
 
 
-@pytest.fixture()
+@pytest.fixture
 def decision_tree_draw_tree(mocker):
     mock = mocker.Mock()
     mock.tree_.node_count = 17
@@ -38,20 +44,73 @@ def decision_tree_draw_tree(mocker):
     mock.tree_.children_right = np.array([2, -1, 12, 7, 6, -1, -1, 9, -1, 11, -1, -1, 16, 15, -1, -1, -1])
     mock.tree_.feature = np.array([3, -2, 3, 2, 3, -2, -2, 3, -2, 2, -2, -2, 2, 1, -2, -2, -2])
     mock.tree_.threshold = np.array(
-        [0.80000001, -2., 1.75, 4.95000005, 1.65000004, -2., -2., 1.55000001, -2., 5.45000005, -2., -2., 4.85000014,
-         3.10000002, -2., -2., -2.])
+        [
+            0.80000001,
+            -2.0,
+            1.75,
+            4.95000005,
+            1.65000004,
+            -2.0,
+            -2.0,
+            1.55000001,
+            -2.0,
+            5.45000005,
+            -2.0,
+            -2.0,
+            4.85000014,
+            3.10000002,
+            -2.0,
+            -2.0,
+            -2.0,
+        ]
+    )
     mock.tree_.value = np.array(
-        [[[0.33333333, 0.33333333, 0.33333333]], [[1., 0., 0.]], [[0., 0.5, 0.5]], [[0., 0.90740741, 0.09259259]],
-         [[0., 0.97916667, 0.02083333]], [[0., 1., 0.]], [[0., 0., 1.]], [[0., 0.33333333, 0.66666667]], [[0., 0., 1.]],
-         [[0., 0.66666667, 0.33333333]], [[0., 1., 0.]], [[0., 0., 1.]], [[0., 0.02173913, 0.97826087]],
-         [[0., 0.33333333, 0.66666667]], [[0., 0., 1.]], [[0., 1., 0.]], [[0., 0., 1.]]])
+        [
+            [[0.33333333, 0.33333333, 0.33333333]],
+            [[1.0, 0.0, 0.0]],
+            [[0.0, 0.5, 0.5]],
+            [[0.0, 0.90740741, 0.09259259]],
+            [[0.0, 0.97916667, 0.02083333]],
+            [[0.0, 1.0, 0.0]],
+            [[0.0, 0.0, 1.0]],
+            [[0.0, 0.33333333, 0.66666667]],
+            [[0.0, 0.0, 1.0]],
+            [[0.0, 0.66666667, 0.33333333]],
+            [[0.0, 1.0, 0.0]],
+            [[0.0, 0.0, 1.0]],
+            [[0.0, 0.02173913, 0.97826087]],
+            [[0.0, 0.33333333, 0.66666667]],
+            [[0.0, 0.0, 1.0]],
+            [[0.0, 1.0, 0.0]],
+            [[0.0, 0.0, 1.0]],
+        ]
+    )
     mock.tree_.impurity = np.array(
-        [0.66666667, 0., 0.5, 0.16803841, 0.04079861, 0., 0., 0.44444444, 0., 0.44444444, 0., 0., 0.04253308,
-         0.44444444, 0., 0., 0.])
+        [
+            0.66666667,
+            0.0,
+            0.5,
+            0.16803841,
+            0.04079861,
+            0.0,
+            0.0,
+            0.44444444,
+            0.0,
+            0.44444444,
+            0.0,
+            0.0,
+            0.04253308,
+            0.44444444,
+            0.0,
+            0.0,
+            0.0,
+        ]
+    )
     mock.tree_.n_node_samples = np.array([150, 50, 100, 54, 48, 47, 1, 6, 3, 3, 2, 1, 46, 3, 2, 1, 43])
     mock.tree_.n_classes = np.array([3])
     mock.tree_.weighted_n_node_samples = np.array(
-        [150., 50., 100., 54., 48., 47., 1., 6., 3., 3., 2., 1., 46., 3., 2., 1., 43.])
+        [150.0, 50.0, 100.0, 54.0, 48.0, 47.0, 1.0, 6.0, 3.0, 3.0, 2.0, 1.0, 46.0, 3.0, 2.0, 1.0, 43.0]
+    )
 
     mock.classes_ = np.array([0, 1, 2])
     mock.n_classes_ = 3
@@ -80,9 +139,9 @@ def decision_tree_draw_tree(mocker):
     mock_tags.multioutput = False
     mock_tags.pairwise = False
     mock_tags.preserves_dtype = []
-    mock_tags.X_types = ['2darray']
-    mock_tags.y_types = ['1dlabels']
-    mock_tags.target_tags = ['multiclass']
+    mock_tags.X_types = ["2darray"]
+    mock_tags.y_types = ["1dlabels"]
+    mock_tags.target_tags = ["multiclass"]
     mock_tags._estimator_type = "classifier"
 
     # Add the __sklearn_tags__ method that returns the mock_tags object
@@ -91,34 +150,188 @@ def decision_tree_draw_tree(mocker):
     # Add some fitted attributes to make the estimator appear fitted
     # mock.feature_importances_ = np.random.Generator(4)
     mock.n_features_ = 4
-    
+
     return mock
 
 
-@pytest.fixture()
+@pytest.fixture
 def importance():
-    return [0.047304175084187376, 0.011129476233187116, 0.01289095487553893, 0.015528563988219685,
-            0.010904371085026893, 0.03088871541039015, 0.03642466650007851, 0.005758395681352302,
-            0.3270373201417306, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3.2562763221434323e-08, 0, 0,
-            1.3846860504742983e-05, 0, 0, 0, 0, 0, 0, 7.31917344936033e-07, 3.689321224943123e-05, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0.5019726768895573, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0.00010917955786877644, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    return [
+        0.047304175084187376,
+        0.011129476233187116,
+        0.01289095487553893,
+        0.015528563988219685,
+        0.010904371085026893,
+        0.03088871541039015,
+        0.03642466650007851,
+        0.005758395681352302,
+        0.3270373201417306,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        3.2562763221434323e-08,
+        0,
+        0,
+        1.3846860504742983e-05,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        7.31917344936033e-07,
+        3.689321224943123e-05,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.5019726768895573,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0.00010917955786877644,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ]
 
 
-@pytest.fixture()
+@pytest.fixture
 def features():
-    return ['x1', 'x2', 'x3', 'x4', 'x5', 'x6', 'x8', 'x9', 'x11', 'x7_value_0', 'x7_value_1', 'x7_value_10',
-            'x7_value_11', 'x7_value_12', 'x7_value_13', 'x7_value_14', 'x7_value_15', 'x7_value_16', 'x7_value_17',
-            'x7_value_18', 'x7_value_19', 'x7_value_2', 'x7_value_20', 'x7_value_21', 'x7_value_22', 'x7_value_23',
-            'x7_value_24', 'x7_value_25', 'x7_value_26', 'x7_value_27', 'x7_value_28', 'x7_value_29', 'x7_value_3',
-            'x7_value_30', 'x7_value_31', 'x7_value_32', 'x7_value_33', 'x7_value_34', 'x7_value_35', 'x7_value_36',
-            'x7_value_37', 'x7_value_38', 'x7_value_39', 'x7_value_4', 'x7_value_40', 'x7_value_41', 'x7_value_42',
-            'x7_value_43', 'x7_value_44', 'x7_value_45', 'x7_value_46', 'x7_value_47', 'x7_value_48', 'x7_value_49',
-            'x7_value_5', 'x7_value_50', 'x7_value_51', 'x7_value_52', 'x7_value_53', 'x7_value_54', 'x7_value_55',
-            'x7_value_56', 'x7_value_57', 'x7_value_58', 'x7_value_59', 'x7_value_6', 'x7_value_60', 'x7_value_61',
-            'x7_value_62', 'x7_value_63', 'x7_value_64', 'x7_value_65', 'x7_value_66', 'x7_value_67', 'x7_value_68',
-            'x7_value_69', 'x7_value_7', 'x7_value_70', 'x7_value_71', 'x7_value_8', 'x7_value_9', 'x10_value_0',
-            'x10_value_1', 'x10_value_2']
+    return [
+        "x1",
+        "x2",
+        "x3",
+        "x4",
+        "x5",
+        "x6",
+        "x8",
+        "x9",
+        "x11",
+        "x7_value_0",
+        "x7_value_1",
+        "x7_value_10",
+        "x7_value_11",
+        "x7_value_12",
+        "x7_value_13",
+        "x7_value_14",
+        "x7_value_15",
+        "x7_value_16",
+        "x7_value_17",
+        "x7_value_18",
+        "x7_value_19",
+        "x7_value_2",
+        "x7_value_20",
+        "x7_value_21",
+        "x7_value_22",
+        "x7_value_23",
+        "x7_value_24",
+        "x7_value_25",
+        "x7_value_26",
+        "x7_value_27",
+        "x7_value_28",
+        "x7_value_29",
+        "x7_value_3",
+        "x7_value_30",
+        "x7_value_31",
+        "x7_value_32",
+        "x7_value_33",
+        "x7_value_34",
+        "x7_value_35",
+        "x7_value_36",
+        "x7_value_37",
+        "x7_value_38",
+        "x7_value_39",
+        "x7_value_4",
+        "x7_value_40",
+        "x7_value_41",
+        "x7_value_42",
+        "x7_value_43",
+        "x7_value_44",
+        "x7_value_45",
+        "x7_value_46",
+        "x7_value_47",
+        "x7_value_48",
+        "x7_value_49",
+        "x7_value_5",
+        "x7_value_50",
+        "x7_value_51",
+        "x7_value_52",
+        "x7_value_53",
+        "x7_value_54",
+        "x7_value_55",
+        "x7_value_56",
+        "x7_value_57",
+        "x7_value_58",
+        "x7_value_59",
+        "x7_value_6",
+        "x7_value_60",
+        "x7_value_61",
+        "x7_value_62",
+        "x7_value_63",
+        "x7_value_64",
+        "x7_value_65",
+        "x7_value_66",
+        "x7_value_67",
+        "x7_value_68",
+        "x7_value_69",
+        "x7_value_7",
+        "x7_value_70",
+        "x7_value_71",
+        "x7_value_8",
+        "x7_value_9",
+        "x10_value_0",
+        "x10_value_1",
+        "x10_value_2",
+    ]
 
 
 @pytest.fixture(autouse=True)
@@ -128,96 +341,170 @@ def setup_teardown():
     plt.close(plt.gcf())
 
 
-@pytest.mark.parametrize("tree_name, expected_name", [
-    ("iris_tree", "def iris_tree(petal width (cm), petal length (cm)):"),
-    (None, "def tree(petal width (cm), petal length (cm)):")
-], ids=["default", "no_tree_name"])
+@pytest.mark.parametrize(
+    "tree_name, expected_name",
+    [
+        ("iris_tree", "def iris_tree(petal width (cm), petal length (cm)):"),
+        (None, "def tree(petal width (cm), petal length (cm)):"),
+    ],
+    ids=["default", "no_tree_name"],
+)
 def test_print_decision_paths(tree_name, expected_name, decision_tree_generate_decision_paths):
     with pytest.warns(DeprecationWarning, match="This module is deprecated. Use sklearn.tree.export_text instead"):
-        result = generate_decision_paths(decision_tree_generate_decision_paths,
-                                         ['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)',
-                                          'petal width (cm)'],
-                                         ['setosa', 'versicolor', 'virginica'], tree_name, "  ")
+        result = generate_decision_paths(
+            decision_tree_generate_decision_paths,
+            ["sepal length (cm)", "sepal width (cm)", "petal length (cm)", "petal width (cm)"],
+            ["setosa", "versicolor", "virginica"],
+            tree_name,
+            "  ",
+        )
 
     assert result.startswith(expected_name)
 
-    expected = f'def {tree_name if tree_name else "tree"}(petal width (cm), petal length (cm)):' + os.linesep + \
-               '  if petal width (cm) <= 0.8000:' + os.linesep + \
-               '    # return class setosa with probability 0.5000' + os.linesep + \
-               '    return ("setosa", 0.5000)' + os.linesep + \
-               '  else:  # if petal width (cm) > 0.8000' + os.linesep + \
-               '    if petal width (cm) <= 1.7500:' + os.linesep + \
-               '      if petal length (cm) <= 4.9500:' + os.linesep + \
-               '        # return class versicolor with probability 0.9792' + os.linesep + \
-               '        return ("versicolor", 0.9792)' + os.linesep + \
-               '      else:  # if petal length (cm) > 4.9500' + os.linesep + \
-               '        # return class virginica with probability 0.6667' + os.linesep + \
-               '        return ("virginica", 0.6667)' + os.linesep + \
-               '    else:  # if petal width (cm) > 1.7500' + os.linesep + \
-               '      if petal length (cm) <= 4.8500:' + os.linesep + \
-               '        # return class virginica with probability 0.6667' + os.linesep + \
-               '        return ("virginica", 0.6667)' + os.linesep + \
-               '      else:  # if petal length (cm) > 4.8500' + os.linesep + \
-               '        # return class virginica with probability 0.5000' + os.linesep + \
-               '        return ("virginica", 0.5000)' + os.linesep
+    expected = (
+        f"def {tree_name if tree_name else 'tree'}(petal width (cm), petal length (cm)):"
+        + os.linesep
+        + "  if petal width (cm) <= 0.8000:"
+        + os.linesep
+        + "    # return class setosa with probability 0.5000"
+        + os.linesep
+        + '    return ("setosa", 0.5000)'
+        + os.linesep
+        + "  else:  # if petal width (cm) > 0.8000"
+        + os.linesep
+        + "    if petal width (cm) <= 1.7500:"
+        + os.linesep
+        + "      if petal length (cm) <= 4.9500:"
+        + os.linesep
+        + "        # return class versicolor with probability 0.9792"
+        + os.linesep
+        + '        return ("versicolor", 0.9792)'
+        + os.linesep
+        + "      else:  # if petal length (cm) > 4.9500"
+        + os.linesep
+        + "        # return class virginica with probability 0.6667"
+        + os.linesep
+        + '        return ("virginica", 0.6667)'
+        + os.linesep
+        + "    else:  # if petal width (cm) > 1.7500"
+        + os.linesep
+        + "      if petal length (cm) <= 4.8500:"
+        + os.linesep
+        + "        # return class virginica with probability 0.6667"
+        + os.linesep
+        + '        return ("virginica", 0.6667)'
+        + os.linesep
+        + "      else:  # if petal length (cm) > 4.8500"
+        + os.linesep
+        + "        # return class virginica with probability 0.5000"
+        + os.linesep
+        + '        return ("virginica", 0.5000)'
+        + os.linesep
+    )
 
     assert result == expected
 
 
 def test_print_decision_paths_no_feature_names(decision_tree_generate_decision_paths):
     with pytest.warns(DeprecationWarning, match="This module is deprecated. Use sklearn.tree.export_text instead"):
-        result = generate_decision_paths(decision_tree_generate_decision_paths, None,
-                                         ['setosa', 'versicolor', 'virginica'], "iris_tree", "  ")
+        result = generate_decision_paths(
+            decision_tree_generate_decision_paths, None, ["setosa", "versicolor", "virginica"], "iris_tree", "  "
+        )
 
-    expected = 'def iris_tree(feature_3, feature_2):' + os.linesep + \
-               '  if feature_3 <= 0.8000:' + os.linesep + \
-               '    # return class setosa with probability 0.5000' + os.linesep + \
-               '    return ("setosa", 0.5000)' + os.linesep + \
-               '  else:  # if feature_3 > 0.8000' + os.linesep + \
-               '    if feature_3 <= 1.7500:' + os.linesep + \
-               '      if feature_2 <= 4.9500:' + os.linesep + \
-               '        # return class versicolor with probability 0.9792' + os.linesep + \
-               '        return ("versicolor", 0.9792)' + os.linesep + \
-               '      else:  # if feature_2 > 4.9500' + os.linesep + \
-               '        # return class virginica with probability 0.6667' + os.linesep + \
-               '        return ("virginica", 0.6667)' + os.linesep + \
-               '    else:  # if feature_3 > 1.7500' + os.linesep + \
-               '      if feature_2 <= 4.8500:' + os.linesep + \
-               '        # return class virginica with probability 0.6667' + os.linesep + \
-               '        return ("virginica", 0.6667)' + os.linesep + \
-               '      else:  # if feature_2 > 4.8500' + os.linesep + \
-               '        # return class virginica with probability 0.5000' + os.linesep + \
-               '        return ("virginica", 0.5000)' + os.linesep
+    expected = (
+        "def iris_tree(feature_3, feature_2):"
+        + os.linesep
+        + "  if feature_3 <= 0.8000:"
+        + os.linesep
+        + "    # return class setosa with probability 0.5000"
+        + os.linesep
+        + '    return ("setosa", 0.5000)'
+        + os.linesep
+        + "  else:  # if feature_3 > 0.8000"
+        + os.linesep
+        + "    if feature_3 <= 1.7500:"
+        + os.linesep
+        + "      if feature_2 <= 4.9500:"
+        + os.linesep
+        + "        # return class versicolor with probability 0.9792"
+        + os.linesep
+        + '        return ("versicolor", 0.9792)'
+        + os.linesep
+        + "      else:  # if feature_2 > 4.9500"
+        + os.linesep
+        + "        # return class virginica with probability 0.6667"
+        + os.linesep
+        + '        return ("virginica", 0.6667)'
+        + os.linesep
+        + "    else:  # if feature_3 > 1.7500"
+        + os.linesep
+        + "      if feature_2 <= 4.8500:"
+        + os.linesep
+        + "        # return class virginica with probability 0.6667"
+        + os.linesep
+        + '        return ("virginica", 0.6667)'
+        + os.linesep
+        + "      else:  # if feature_2 > 4.8500"
+        + os.linesep
+        + "        # return class virginica with probability 0.5000"
+        + os.linesep
+        + '        return ("virginica", 0.5000)'
+        + os.linesep
+    )
 
     assert result == expected
 
 
 def test_print_decision_paths_no_class_names(decision_tree_generate_decision_paths):
     with pytest.warns(DeprecationWarning, match="This module is deprecated. Use sklearn.tree.export_text instead"):
-        result = generate_decision_paths(decision_tree_generate_decision_paths,
-                                         ['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)',
-                                          'petal width (cm)'],
-                                         None, "iris_tree", "  ")
+        result = generate_decision_paths(
+            decision_tree_generate_decision_paths,
+            ["sepal length (cm)", "sepal width (cm)", "petal length (cm)", "petal width (cm)"],
+            None,
+            "iris_tree",
+            "  ",
+        )
 
-    expected = 'def iris_tree(petal width (cm), petal length (cm)):' + os.linesep + \
-               '  if petal width (cm) <= 0.8000:' + os.linesep + \
-               '    # return class class_0 with probability 0.5000' + os.linesep + \
-               '    return ("class_0", 0.5000)' + os.linesep + \
-               '  else:  # if petal width (cm) > 0.8000' + os.linesep + \
-               '    if petal width (cm) <= 1.7500:' + os.linesep + \
-               '      if petal length (cm) <= 4.9500:' + os.linesep + \
-               '        # return class class_1 with probability 0.9792' + os.linesep + \
-               '        return ("class_1", 0.9792)' + os.linesep + \
-               '      else:  # if petal length (cm) > 4.9500' + os.linesep + \
-               '        # return class class_2 with probability 0.6667' + os.linesep + \
-               '        return ("class_2", 0.6667)' + os.linesep + \
-               '    else:  # if petal width (cm) > 1.7500' + os.linesep + \
-               '      if petal length (cm) <= 4.8500:' + os.linesep + \
-               '        # return class class_2 with probability 0.6667' + os.linesep + \
-               '        return ("class_2", 0.6667)' + os.linesep + \
-               '      else:  # if petal length (cm) > 4.8500' + os.linesep + \
-               '        # return class class_2 with probability 0.5000' + os.linesep + \
-               '        return ("class_2", 0.5000)' + os.linesep
+    expected = (
+        "def iris_tree(petal width (cm), petal length (cm)):"
+        + os.linesep
+        + "  if petal width (cm) <= 0.8000:"
+        + os.linesep
+        + "    # return class class_0 with probability 0.5000"
+        + os.linesep
+        + '    return ("class_0", 0.5000)'
+        + os.linesep
+        + "  else:  # if petal width (cm) > 0.8000"
+        + os.linesep
+        + "    if petal width (cm) <= 1.7500:"
+        + os.linesep
+        + "      if petal length (cm) <= 4.9500:"
+        + os.linesep
+        + "        # return class class_1 with probability 0.9792"
+        + os.linesep
+        + '        return ("class_1", 0.9792)'
+        + os.linesep
+        + "      else:  # if petal length (cm) > 4.9500"
+        + os.linesep
+        + "        # return class class_2 with probability 0.6667"
+        + os.linesep
+        + '        return ("class_2", 0.6667)'
+        + os.linesep
+        + "    else:  # if petal width (cm) > 1.7500"
+        + os.linesep
+        + "      if petal length (cm) <= 4.8500:"
+        + os.linesep
+        + "        # return class class_2 with probability 0.6667"
+        + os.linesep
+        + '        return ("class_2", 0.6667)'
+        + os.linesep
+        + "      else:  # if petal length (cm) > 4.8500"
+        + os.linesep
+        + "        # return class class_2 with probability 0.5000"
+        + os.linesep
+        + '        return ("class_2", 0.5000)'
+        + os.linesep
+    )
 
     assert result == expected
 
@@ -225,9 +512,11 @@ def test_print_decision_paths_no_class_names(decision_tree_generate_decision_pat
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR, tolerance=53)
 def test_draw_tree(decision_tree_draw_tree):
     with pytest.warns(DeprecationWarning, match="This module is deprecated. Use sklearn.tree.plot_tree instead"):
-        draw_tree(decision_tree_draw_tree,
-                  ['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)'],
-                  ['setosa', 'versicolor', 'virginica'])
+        draw_tree(
+            decision_tree_draw_tree,
+            ["sepal length (cm)", "sepal width (cm)", "petal length (cm)", "petal width (cm)"],
+            ["setosa", "versicolor", "virginica"],
+        )
     return plt.gcf()
 
 
@@ -236,9 +525,12 @@ def test_draw_tree_exists_ax(decision_tree_draw_tree):
     fig, ax = plt.subplots()
     ax.set_title("My ax")
     with pytest.warns(DeprecationWarning, match="This module is deprecated. Use sklearn.tree.plot_tree instead"):
-        draw_tree(decision_tree_draw_tree,
-                  ['sepal length (cm)', 'sepal width (cm)', 'petal length (cm)', 'petal width (cm)'],
-                  ['setosa', 'versicolor', 'virginica'], ax=ax)
+        draw_tree(
+            decision_tree_draw_tree,
+            ["sepal length (cm)", "sepal width (cm)", "petal length (cm)", "petal width (cm)"],
+            ["setosa", "versicolor", "virginica"],
+            ax=ax,
+        )
 
     assert ax.get_title() == "My ax"
     return fig
@@ -246,16 +538,18 @@ def test_draw_tree_exists_ax(decision_tree_draw_tree):
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR, tolerance=11)
 def test_draw_dot_data():
-    dot_data = "digraph D{\n" \
-               "\tA [shape=diamond]\n" \
-               "\tB [shape=box]\n" \
-               "\tC [shape=circle]\n" \
-               "\n" \
-               "\tA -> B [style=dashed, color=grey]\n" \
-               "\tA -> C [color=\"black:invis:black\"]\n" \
-               "\tA -> D [penwidth=5, arrowhead=none]\n" \
-               "\n" \
-               "}"
+    dot_data = (
+        "digraph D{\n"
+        "\tA [shape=diamond]\n"
+        "\tB [shape=box]\n"
+        "\tC [shape=circle]\n"
+        "\n"
+        "\tA -> B [style=dashed, color=grey]\n"
+        '\tA -> C [color="black:invis:black"]\n'
+        "\tA -> D [penwidth=5, arrowhead=none]\n"
+        "\n"
+        "}"
+    )
 
     draw_dot_data(dot_data)
     return plt.gcf()
@@ -263,16 +557,18 @@ def test_draw_dot_data():
 
 @pytest.mark.mpl_image_compare(baseline_dir=BASELINE_DIR, tolerance=11)
 def test_draw_dot_data_exist_ax():
-    dot_data = "digraph D{\n" \
-               "\tA [shape=diamond]\n" \
-               "\tB [shape=box]\n" \
-               "\tC [shape=circle]\n" \
-               "\n" \
-               "\tA -> B [style=dashed, color=grey]\n" \
-               "\tA -> C [color=\"black:invis:black\"]\n" \
-               "\tA -> D [penwidth=5, arrowhead=none]\n" \
-               "\n" \
-               "}"
+    dot_data = (
+        "digraph D{\n"
+        "\tA [shape=diamond]\n"
+        "\tB [shape=box]\n"
+        "\tC [shape=circle]\n"
+        "\n"
+        "\tA -> B [style=dashed, color=grey]\n"
+        '\tA -> C [color="black:invis:black"]\n'
+        "\tA -> D [penwidth=5, arrowhead=none]\n"
+        "\n"
+        "}"
+    )
 
     fig, ax = plt.subplots()
     ax.set_title("My ax")
@@ -288,7 +584,7 @@ def test_draw_dot_data_empty_input():
 
 
 def test_draw_dot_data_invalid_input(mocker):
-    mock_pydotplus = mocker.patch('ds_utils.xai.pydotplus')
+    mock_pydotplus = mocker.patch("ds_utils.xai.pydotplus")
     mock_pydotplus.graph_from_dot_data.side_effect = Exception("Invalid dot data")
 
     with pytest.raises(ValueError, match="Failed to create graph from dot data"):
@@ -317,19 +613,12 @@ def test_plot_features_importance_exists_ax(importance, features):
 
 
 def test_plot_features_importance_mismatched_lengths():
-    """
-    Test that ValueError is raised for mismatched feature and importance lengths.
-    """
+    """Test that ValueError is raised for mismatched feature and importance lengths."""
     with pytest.raises(ValueError, match="feature_names and feature_importance must have the same length"):
-        plot_features_importance(['feature1', 'feature2'], [0.5, 0.3, 0.2])
+        plot_features_importance(["feature1", "feature2"], [0.5, 0.3, 0.2])
 
 
 def test_plot_features_importance_invalid_input_dimensions():
-    """
-    Test that ValueError is raised for multidimensional inputs.
-    """
+    """Test that ValueError is raised for multidimensional inputs."""
     with pytest.raises(ValueError, match="feature_names and feature_importance must be 1-dimensional"):
-        plot_features_importance(
-            np.array([['f1', 'f2'], ['f3', 'f4']]),
-            np.array([[0.5, 0.3], [0.2, 0.1]])
-        )
+        plot_features_importance(np.array([["f1", "f2"], ["f3", "f4"]]), np.array([[0.5, 0.3], [0.2, 0.1]]))


### PR DESCRIPTION
- Add Ruff as a development dependency and configure it with recommended rules, flake8-docstrings, flake8-pytest-style, and isort settings.
- Integrate Ruff checks (format and lint) into the CI pipeline.
- Apply Ruff formatting to the entire codebase.
- Fix numerous linting issues reported by Ruff, primarily related to docstrings (missing, formatting, style), line lengths, and pytest usage (parametrize arguments, broad exceptions, duplicate test cases).
- Address a test failure (`AttributeError`) in `plot_metric_growth_per_labeled_instances` by ensuring `y_train` is handled correctly as a NumPy array.
- Verify Sphinx documentation builds successfully after changes and fix a duplicate link target warning.
- Document the use of Ruff in README.md.