### PR TITLE
Add Directional Bias and Directional Accuracy Metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The API of the package is built to work with the Scikit-Learn API and Matplotlib
 The metrics module is organized into focused submodules:
 - **confusion_matrix** - Confusion matrix visualization and analysis
 - **curves** - ROC and Precision-Recall curves
-- **directional_metrics** - Time-series and forecasting directional metrics
+- **time_series** - Time-series and forecasting directional metrics
 - **learning_curves** - Learning curve visualization
 - **probability_analysis** - Probability calibration and accuracy analysis
 
@@ -154,6 +154,7 @@ print(f"Directional Bias: {bias:.2f}")
 ```
 
 Output:
+```
 Directional Accuracy: 100.00%
 Directional Bias: 1.00
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The API of the package is built to work with the Scikit-Learn API and Matplotlib
 The metrics module is organized into focused submodules:
 - **confusion_matrix** - Confusion matrix visualization and analysis
 - **curves** - ROC and Precision-Recall curves
+- **directional_metrics** - Time-series and forecasting directional metrics
 - **learning_curves** - Learning curve visualization
 - **probability_analysis** - Probability calibration and accuracy analysis
 
@@ -130,6 +131,27 @@ fig.show()
 ```
 
 ![plot precision recall curve with thresholds annotations](https://raw.githubusercontent.com/idanmoradarthas/DataScienceUtils/master/tests/baseline_images/test_metrics/test_curves/test_plot_precision_recall_curve_with_thresholds_annotations_default.png)
+
+### Directional Metrics
+
+Directional metrics evaluate forecasting performance, especially in time-series and financial contexts where trend direction is key.
+
+```python
+from ds_utils.metrics.time_series import directional_accuracy_score, directional_bias_score
+import numpy as np
+
+# Directional accuracy — time series mode (uses previous value as baseline)
+y_true = np.array([100, 102, 98, 101, 99])
+y_pred = np.array([101, 103, 97, 102, 98])
+da = directional_accuracy_score(y_true, y_pred)
+print(f"Directional Accuracy: {da:.2%}")   # 100.00%
+
+# Directional bias — detect systematic over/under-prediction
+y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+y_pred = np.array([1.1, 2.1, 3.1, 4.1, 5.1])
+bias = directional_bias_score(y_true, y_pred)
+print(f"Directional Bias: {bias:.2f}")   # 1.00
+```
 
 ### Plot Error Analysis Chart
 

--- a/README.md
+++ b/README.md
@@ -144,13 +144,15 @@ import numpy as np
 y_true = np.array([100, 102, 98, 101, 99])
 y_pred = np.array([101, 103, 97, 102, 98])
 da = directional_accuracy_score(y_true, y_pred)
-print(f"Directional Accuracy: {da:.2%}")   # 100.00%
+print(f"Directional Accuracy: {da:.2%}")
+# Output: Directional Accuracy: 100.00%
 
 # Directional bias — detect systematic over/under-prediction
 y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
 y_pred = np.array([1.1, 2.1, 3.1, 4.1, 5.1])
 bias = directional_bias_score(y_true, y_pred)
-print(f"Directional Bias: {bias:.2f}")   # 1.00
+print(f"Directional Bias: {bias:.2f}")
+# Output: Directional Bias: 1.00
 ```
 
 ### Plot Error Analysis Chart

--- a/README.md
+++ b/README.md
@@ -145,14 +145,17 @@ y_true = np.array([100, 102, 98, 101, 99])
 y_pred = np.array([101, 103, 97, 102, 98])
 da = directional_accuracy_score(y_true, y_pred)
 print(f"Directional Accuracy: {da:.2%}")
-# Output: Directional Accuracy: 100.00%
 
 # Directional bias — detect systematic over/under-prediction
 y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
 y_pred = np.array([1.1, 2.1, 3.1, 4.1, 5.1])
 bias = directional_bias_score(y_true, y_pred)
 print(f"Directional Bias: {bias:.2f}")
-# Output: Directional Bias: 1.00
+```
+
+Output:
+Directional Accuracy: 100.00%
+Directional Bias: 1.00
 ```
 
 ### Plot Error Analysis Chart

--- a/docs/source/metrics/directional_metrics.rst
+++ b/docs/source/metrics/directional_metrics.rst
@@ -19,8 +19,8 @@ Code Example
     import numpy as np
 
     # Directional accuracy — time series mode (uses previous value as baseline)
-    # true changes from prev: +2, -4, +3, -2
-    # pred changes from prev: +1, -5, +4, -1  -> all directions match
+    # true changes from baseline: +2, -4, +3, -2
+    # pred changes from baseline: +3, -5, +4, -3  -> all directions match
     y_true = np.array([100, 102, 98, 101, 99])
     y_pred = np.array([101, 103, 97, 102, 98])
     da = directional_accuracy_score(y_true, y_pred)

--- a/docs/source/metrics/directional_metrics.rst
+++ b/docs/source/metrics/directional_metrics.rst
@@ -5,18 +5,17 @@ Directional metrics are used to evaluate the performance of forecasting models,
 especially in time-series and financial contexts where the trend direction is
 often more important than the exact magnitude of the change.
 
+Directional Accuracy Score
+--------------------------
+
 .. autofunction:: ds_utils.metrics.time_series.directional_accuracy_score
 
-.. autofunction:: ds_utils.metrics.time_series.directional_bias_score
-
 Code Example
-============
-
-.. highlight:: python
+~~~~~~~~~~~~
 
 .. code-block:: python
 
-    from ds_utils.metrics.time_series import directional_accuracy_score, directional_bias_score
+    from ds_utils.metrics.time_series import directional_accuracy_score
     import numpy as np
 
     # Directional accuracy — time series mode (uses previous value as baseline)
@@ -26,7 +25,22 @@ Code Example
     y_pred = np.array([101, 103, 97, 102, 98])
     da = directional_accuracy_score(y_true, y_pred)
     print(f"Directional Accuracy: {da:.2%}")
-    # Output: Directional Accuracy: 100.00%
+
+Output:
+Directional Accuracy: 100.00%
+
+Directional Bias Score
+----------------------
+
+.. autofunction:: ds_utils.metrics.time_series.directional_bias_score
+
+Code Example
+~~~~~~~~~~~~
+
+.. code-block:: python
+
+    from ds_utils.metrics.time_series import directional_bias_score
+    import numpy as np
 
     # Directional bias — detect systematic over/under-prediction
     # All predictions are 0.1 above the true value
@@ -34,4 +48,6 @@ Code Example
     y_pred = np.array([1.1, 2.1, 3.1, 4.1, 5.1])
     bias = directional_bias_score(y_true, y_pred)
     print(f"Directional Bias: {bias:.2f}")
-    # Output: Directional Bias: 1.00
+
+Output:
+Directional Bias: 1.00

--- a/docs/source/metrics/directional_metrics.rst
+++ b/docs/source/metrics/directional_metrics.rst
@@ -8,3 +8,30 @@ often more important than the exact magnitude of the change.
 .. autofunction:: ds_utils.metrics.time_series.directional_accuracy_score
 
 .. autofunction:: ds_utils.metrics.time_series.directional_bias_score
+
+Code Example
+============
+
+.. highlight:: python
+
+.. code-block:: python
+
+    from ds_utils.metrics.time_series import directional_accuracy_score, directional_bias_score
+    import numpy as np
+
+    # Directional accuracy — time series mode (uses previous value as baseline)
+    # true changes from prev: +2, -4, +3, -2
+    # pred changes from prev: +1, -5, +4, -1  -> all directions match
+    y_true = np.array([100, 102, 98, 101, 99])
+    y_pred = np.array([101, 103, 97, 102, 98])
+    da = directional_accuracy_score(y_true, y_pred)
+    print(f"Directional Accuracy: {da:.2%}")
+    # Output: Directional Accuracy: 100.00%
+
+    # Directional bias — detect systematic over/under-prediction
+    # All predictions are 0.1 above the true value
+    y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    y_pred = np.array([1.1, 2.1, 3.1, 4.1, 5.1])
+    bias = directional_bias_score(y_true, y_pred)
+    print(f"Directional Bias: {bias:.2f}")
+    # Output: Directional Bias: 1.00

--- a/docs/source/metrics/directional_metrics.rst
+++ b/docs/source/metrics/directional_metrics.rst
@@ -26,8 +26,10 @@ Code Example
     da = directional_accuracy_score(y_true, y_pred)
     print(f"Directional Accuracy: {da:.2%}")
 
-Output:
-Directional Accuracy: 100.00%
+.. code-block:: text
+
+    Output:
+    Directional Accuracy: 100.00%
 
 Directional Bias Score
 ----------------------
@@ -49,5 +51,7 @@ Code Example
     bias = directional_bias_score(y_true, y_pred)
     print(f"Directional Bias: {bias:.2f}")
 
-Output:
-Directional Bias: 1.00
+.. code-block:: text
+
+    Output:
+    Directional Bias: 1.00

--- a/docs/source/metrics/directional_metrics.rst
+++ b/docs/source/metrics/directional_metrics.rst
@@ -1,0 +1,10 @@
+Directional Metrics
+===================
+
+Directional metrics are used to evaluate the performance of forecasting models,
+especially in time-series and financial contexts where the trend direction is
+often more important than the exact magnitude of the change.
+
+.. autofunction:: ds_utils.metrics.time_series.directional_accuracy_score
+
+.. autofunction:: ds_utils.metrics.time_series.directional_bias_score

--- a/docs/source/metrics/index.rst
+++ b/docs/source/metrics/index.rst
@@ -10,6 +10,7 @@ The module of metrics contains methods that help to calculate and/or visualize e
    
    confusion_matrix
    curves
+   directional_metrics
    error_analysis
    learning_curves
    probability_analysis

--- a/ds_utils/metrics/__init__.py
+++ b/ds_utils/metrics/__init__.py
@@ -6,4 +6,5 @@ This package provides functions for evaluating and visualizing model performance
 - error_analysis - Tabular error-analysis report generation
 - learning_curves - Learning curve visualization
 - probability_analysis - Probability calibration and accuracy analysis
+- time_series - Time-series forecasting and directional metrics
 """

--- a/ds_utils/metrics/time_series.py
+++ b/ds_utils/metrics/time_series.py
@@ -1,0 +1,209 @@
+"""Time series and forecasting metrics.
+
+This module provides scalar metric functions for time-series forecasting,
+financial modeling, and other use cases where trend direction and bias
+are of primary interest.
+"""
+
+from typing import Optional
+
+import numpy as np
+
+
+def directional_accuracy_score(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    baseline: Optional[np.ndarray] = None,
+    sample_weight: Optional[np.ndarray] = None,
+    handle_equal: str = "exclude",
+) -> float:
+    """Calculate the directional accuracy score.
+
+    Directional accuracy (DA) measures the proportion of time steps for which
+    the predicted direction of change matches the true direction of change,
+    relative to a baseline.
+
+    The formula is:
+    DA = (1/n) * Σ I(sign(y_true - baseline) == sign(y_pred - baseline))
+
+    :param y_true: Ground truth (correct) target values.
+    :param y_pred: Estimated target values.
+    :param baseline: Baseline values to compare against. If None, uses the previous
+                     value of y_true (time-series mode). If provided, must have
+                     the same shape as y_true.
+    :param sample_weight: Sample weights.
+    :param handle_equal: How to treat samples where y_true == baseline.
+                         - 'exclude': Filter out these samples (default).
+                         - 'correct': Count as correct if y_pred == baseline, else incorrect.
+                         - 'incorrect': Always count as incorrect.
+    :return: Directional accuracy score as a float.
+    :raises ValueError: If handle_equal is invalid, if shapes mismatch, or if
+                        insufficient samples are provided for time-series mode.
+
+    Time series example:
+    >>> import numpy as np
+    >>> y_true = np.array([100, 102, 98, 101, 99])
+    >>> y_pred = np.array([100.5, 103, 97, 102, 98])
+    >>> directional_accuracy_score(y_true, y_pred)
+    1.0
+
+    Custom baseline example:
+    >>> y_true = np.array([102, 98, 101, 99, 102])
+    >>> baseline = np.array([100, 100, 100, 100, 100])
+    >>> y_pred = np.array([101, 99, 99, 101, 99])
+    >>> directional_accuracy_score(y_true, y_pred, baseline=baseline)
+    0.4
+    """
+    if handle_equal not in ["exclude", "correct", "incorrect"]:
+        raise ValueError(f"handle_equal must be 'exclude', 'correct', or 'incorrect', got '{handle_equal}'")
+
+    y_true = np.asarray(y_true).flatten()
+    y_pred = np.asarray(y_pred).flatten()
+
+    if y_true.shape != y_pred.shape:
+        raise ValueError(f"Shape mismatch: y_true {y_true.shape} and y_pred {y_pred.shape} must match.")
+
+    if baseline is None:
+        if len(y_true) < 2:
+            raise ValueError("Time-series mode (baseline=None) requires at least 2 samples.")
+        baseline = y_true[:-1]
+        y_true = y_true[1:]
+        y_pred = y_pred[1:]
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight).flatten()
+            if len(sample_weight) != len(y_true) + 1:
+                raise ValueError(
+                    f"Sample weight length ({len(sample_weight)}) does not match "
+                    f"original sample count ({len(y_true) + 1})"
+                )
+            sample_weight = sample_weight[1:]
+    else:
+        baseline = np.asarray(baseline).flatten()
+        if baseline.shape != y_true.shape:
+            raise ValueError(f"Shape mismatch: baseline {baseline.shape} and y_true {y_true.shape} must match.")
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight).flatten()
+            if len(sample_weight) != len(y_true):
+                raise ValueError(
+                    f"Sample weight length ({len(sample_weight)}) does not match "
+                    f"sample count ({len(y_true)})"
+                )
+
+    true_direction = np.sign(y_true - baseline)
+    pred_direction = np.sign(y_pred - baseline)
+
+    if handle_equal == "exclude":
+        mask = true_direction != 0
+        true_direction = true_direction[mask]
+        pred_direction = pred_direction[mask]
+        if sample_weight is not None:
+            sample_weight = sample_weight[mask]
+        if len(true_direction) == 0:
+            raise ValueError("No valid samples remain after filtering")
+        correct_direction = true_direction == pred_direction
+    elif handle_equal == "correct":
+        equal_mask = true_direction == 0
+        correct_direction = np.where(
+            equal_mask,
+            pred_direction == 0,
+            true_direction == pred_direction,
+        )
+    else:  # handle_equal == "incorrect"
+        equal_mask = true_direction == 0
+        correct_direction = np.where(
+            equal_mask,
+            False,
+            true_direction == pred_direction,
+        )
+
+    if sample_weight is None:
+        accuracy = correct_direction.mean()
+    else:
+        w = sample_weight / sample_weight.sum()
+        accuracy = (correct_direction * w).sum()
+
+    return float(accuracy)
+
+
+def directional_bias_score(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    sample_weight: Optional[np.ndarray] = None,
+    handle_equal: str = "exclude",
+) -> float:
+    """Calculate the directional bias score.
+
+    Directional bias (DB) measures the systematic tendency of a model to
+    over-predict or under-predict the target values.
+
+    The formula is:
+    DB = (n_over - n_under) / n
+
+    :param y_true: Ground truth (correct) target values.
+    :param y_pred: Estimated target values.
+    :param sample_weight: Sample weights.
+    :param handle_equal: How to treat samples where y_pred == y_true.
+                         - 'exclude': Filter out these samples (default).
+                         - 'neutral': Keep samples; they contribute 0 to the bias.
+    :return: Directional bias score as a float in [-1, 1].
+             1.0 = complete over-prediction, -1.0 = complete under-prediction,
+             0.0 = balanced predictions.
+    :raises ValueError: If handle_equal is invalid, if shapes mismatch, or if
+                        no samples remain after filtering.
+
+    Complete over-prediction example:
+    >>> import numpy as np
+    >>> y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    >>> y_pred = np.array([1.1, 2.1, 3.1, 4.1, 5.1])
+    >>> directional_bias_score(y_true, y_pred)
+    1.0
+
+    Complete under-prediction example:
+    >>> y_pred = np.array([0.9, 1.9, 2.9, 3.9, 4.9])
+    >>> directional_bias_score(y_true, y_pred)
+    -1.0
+
+    Balanced example:
+    >>> y_pred = np.array([1.1, 1.9, 3.1, 3.9, 5.0])
+    >>> directional_bias_score(y_true, y_pred)
+    0.0
+    """
+    if handle_equal not in ["exclude", "neutral"]:
+        raise ValueError(f"handle_equal must be 'exclude' or 'neutral', got '{handle_equal}'")
+
+    y_true = np.asarray(y_true).flatten()
+    y_pred = np.asarray(y_pred).flatten()
+
+    if y_true.shape != y_pred.shape:
+        raise ValueError(f"Shape mismatch: y_true {y_true.shape} and y_pred {y_pred.shape} must match.")
+
+    if sample_weight is not None:
+        sample_weight = np.asarray(sample_weight).flatten()
+        if len(sample_weight) != len(y_true):
+            raise ValueError(
+                f"Sample weight length ({len(sample_weight)}) does not match "
+                f"sample count ({len(y_true)})"
+            )
+
+    errors = y_pred - y_true
+
+    if handle_equal == "exclude":
+        mask = errors != 0
+        errors = errors[mask]
+        if sample_weight is not None:
+            sample_weight = sample_weight[mask]
+        if len(errors) == 0:
+            raise ValueError("No valid samples remain after filtering")
+
+    over_predictions = errors > 0
+    under_predictions = errors < 0
+
+    if sample_weight is None:
+        prop_over = over_predictions.mean()
+        prop_under = under_predictions.mean()
+    else:
+        w = sample_weight / sample_weight.sum()
+        prop_over = (over_predictions * w).sum()
+        prop_under = (under_predictions * w).sum()
+
+    return float(prop_over - prop_under)

--- a/ds_utils/metrics/time_series.py
+++ b/ds_utils/metrics/time_series.py
@@ -66,16 +66,16 @@ def directional_accuracy_score(
     if baseline is None:
         if len(y_true) < 2:
             raise ValueError("Time-series mode (baseline=None) requires at least 2 samples.")
+        if sample_weight is not None:
+            sample_weight = np.asarray(sample_weight).flatten()
+            if len(sample_weight) != len(y_true):
+                raise ValueError(
+                    f"Sample weight length ({len(sample_weight)}) does not match sample count ({len(y_true)})"
+                )
         baseline = y_true[:-1]
         y_true = y_true[1:]
         y_pred = y_pred[1:]
         if sample_weight is not None:
-            sample_weight = np.asarray(sample_weight).flatten()
-            if len(sample_weight) != len(y_true) + 1:
-                raise ValueError(
-                    f"Sample weight length ({len(sample_weight)}) does not match "
-                    f"original sample count ({len(y_true) + 1})"
-                )
             sample_weight = sample_weight[1:]
     else:
         baseline = np.asarray(baseline).flatten()

--- a/ds_utils/metrics/time_series.py
+++ b/ds_utils/metrics/time_series.py
@@ -85,8 +85,7 @@ def directional_accuracy_score(
             sample_weight = np.asarray(sample_weight).flatten()
             if len(sample_weight) != len(y_true):
                 raise ValueError(
-                    f"Sample weight length ({len(sample_weight)}) does not match "
-                    f"sample count ({len(y_true)})"
+                    f"Sample weight length ({len(sample_weight)}) does not match sample count ({len(y_true)})"
                 )
 
     true_direction = np.sign(y_true - baseline)
@@ -180,10 +179,7 @@ def directional_bias_score(
     if sample_weight is not None:
         sample_weight = np.asarray(sample_weight).flatten()
         if len(sample_weight) != len(y_true):
-            raise ValueError(
-                f"Sample weight length ({len(sample_weight)}) does not match "
-                f"sample count ({len(y_true)})"
-            )
+            raise ValueError(f"Sample weight length ({len(sample_weight)}) does not match sample count ({len(y_true)})")
 
     errors = y_pred - y_true
 

--- a/skills/metrics/SKILL.md
+++ b/skills/metrics/SKILL.md
@@ -31,8 +31,7 @@ from ds_utils.metrics.curves import plot_roc_curve_with_thresholds_annotations
 from ds_utils.metrics.curves import plot_precision_recall_curve_with_thresholds_annotations
 from ds_utils.metrics.probability_analysis import plot_error_analysis_chart
 from ds_utils.metrics.error_analysis import generate_error_analysis_report
-from ds_utils.metrics.time_series import directional_accuracy_score
-from ds_utils.metrics.time_series import directional_bias_score
+from ds_utils.metrics.time_series import directional_accuracy_score, directional_bias_score
 ```
 
 ---

--- a/skills/metrics/SKILL.md
+++ b/skills/metrics/SKILL.md
@@ -350,10 +350,13 @@ y_true = np.array([100, 102, 98, 101, 99])
 y_pred = np.array([101, 103, 97, 102, 98])
 da = directional_accuracy_score(y_true, y_pred)
 print(f"Directional Accuracy: {da:.2%}")
+# Output: Directional Accuracy: 100.00%
 
 # Custom baseline
 baseline = np.array([100, 100, 100, 100, 100])
 da = directional_accuracy_score(y_true, y_pred, baseline=baseline)
+print(f"Directional Accuracy (baseline 100): {da:.2%}")
+# Output: Directional Accuracy (baseline 100): 40.00%
 ```
 
 **Parameters:**
@@ -391,6 +394,7 @@ y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
 y_pred = np.array([1.1, 2.1, 3.1, 4.1, 5.1])
 bias = directional_bias_score(y_true, y_pred)
 print(f"Directional Bias: {bias:.2f}")
+# Output: Directional Bias: 1.00
 ```
 
 **Parameters:**

--- a/skills/metrics/SKILL.md
+++ b/skills/metrics/SKILL.md
@@ -352,16 +352,22 @@ y_true = np.array([100, 102, 98, 101, 99])
 y_pred = np.array([101, 103, 97, 102, 98])
 da = directional_accuracy_score(y_true, y_pred)
 print(f"Directional Accuracy: {da:.2%}")
-
-# Custom baseline
-baseline = np.array([100, 100, 100, 100, 100])
-da = directional_accuracy_score(y_true, y_pred, baseline=baseline)
-print(f"Directional Accuracy (baseline 100): {da:.2%}")
 ```
 
 Output:
 Directional Accuracy: 100.00%
-Directional Accuracy (baseline 100): 40.00%
+
+```python
+# Custom baseline — different y_true to illustrate a non-trivial result
+y_true_baseline = np.array([102, 98, 101, 99, 102])
+baseline = np.array([100, 100, 100, 100, 100])
+y_pred_baseline = np.array([101, 99, 99, 101, 99])
+da_baseline = directional_accuracy_score(y_true_baseline, y_pred_baseline, baseline=baseline)
+print(f"Directional Accuracy (custom baseline): {da_baseline:.2%}")
+```
+
+Output:
+Directional Accuracy (custom baseline): 40.00%
 
 **Parameters:**
 

--- a/skills/metrics/SKILL.md
+++ b/skills/metrics/SKILL.md
@@ -350,14 +350,16 @@ y_true = np.array([100, 102, 98, 101, 99])
 y_pred = np.array([101, 103, 97, 102, 98])
 da = directional_accuracy_score(y_true, y_pred)
 print(f"Directional Accuracy: {da:.2%}")
-# Output: Directional Accuracy: 100.00%
 
 # Custom baseline
 baseline = np.array([100, 100, 100, 100, 100])
 da = directional_accuracy_score(y_true, y_pred, baseline=baseline)
 print(f"Directional Accuracy (baseline 100): {da:.2%}")
-# Output: Directional Accuracy (baseline 100): 40.00%
 ```
+
+Output:
+Directional Accuracy: 100.00%
+Directional Accuracy (baseline 100): 40.00%
 
 **Parameters:**
 
@@ -394,8 +396,10 @@ y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
 y_pred = np.array([1.1, 2.1, 3.1, 4.1, 5.1])
 bias = directional_bias_score(y_true, y_pred)
 print(f"Directional Bias: {bias:.2f}")
-# Output: Directional Bias: 1.00
 ```
+
+Output:
+Directional Bias: 1.00
 
 **Parameters:**
 

--- a/skills/metrics/SKILL.md
+++ b/skills/metrics/SKILL.md
@@ -31,6 +31,8 @@ from ds_utils.metrics.curves import plot_roc_curve_with_thresholds_annotations
 from ds_utils.metrics.curves import plot_precision_recall_curve_with_thresholds_annotations
 from ds_utils.metrics.probability_analysis import plot_error_analysis_chart
 from ds_utils.metrics.error_analysis import generate_error_analysis_report
+from ds_utils.metrics.time_series import directional_accuracy_score
+from ds_utils.metrics.time_series import directional_bias_score
 ```
 
 ---
@@ -484,9 +486,12 @@ report_df = generate_error_analysis_report(
 )
 print(report_df)
 
-# 8. Directional Metrics (for time-series/forecasting)
+# 8. Directional Metrics (for time-series/forecasting with continuous targets)
+# Note: these metrics require continuous regression/forecasting outputs, not classifier labels.
 from ds_utils.metrics.time_series import directional_accuracy_score, directional_bias_score
-da = directional_accuracy_score(y_test, y_pred)
-bias = directional_bias_score(y_test, y_pred)
+y_forecast_true = np.array([100, 102, 98, 101, 99])
+y_forecast_pred = np.array([101, 103, 97, 102, 98])
+da = directional_accuracy_score(y_forecast_true, y_forecast_pred)
+bias = directional_bias_score(y_forecast_true, y_forecast_pred)
 print(f"DA: {da:.2%}, Bias: {bias:.2f}")
 ```

--- a/skills/metrics/SKILL.md
+++ b/skills/metrics/SKILL.md
@@ -335,6 +335,79 @@ If analyzing features "age" and "region":
 
 ---
 
+## directional_accuracy_score
+
+Calculates the proportion of time steps for which a model correctly predicts the direction of
+change relative to a baseline. Ideal for time-series forecasting and financial modeling where
+trend direction matters more than exact magnitude.
+
+```python
+from ds_utils.metrics.time_series import directional_accuracy_score
+import numpy as np
+
+# Time series mode (baseline = previous value)
+y_true = np.array([100, 102, 98, 101, 99])
+y_pred = np.array([101, 103, 97, 102, 98])
+da = directional_accuracy_score(y_true, y_pred)
+print(f"Directional Accuracy: {da:.2%}")
+
+# Custom baseline
+baseline = np.array([100, 100, 100, 100, 100])
+da = directional_accuracy_score(y_true, y_pred, baseline=baseline)
+```
+
+**Parameters:**
+
+* `y_true` — array-like of shape (n_samples,). True target values.
+* `y_pred` — array-like of shape (n_samples,). Predicted target values.
+* `baseline` — array-like of shape (n_samples,), optional. Baseline values. If None, uses
+  `y_true[i-1]` (time series default). Requires `len(y_true) >= 2`.
+* `sample_weight` — array-like, optional. Sample weights.
+* `handle_equal` — `{'exclude', 'correct', 'incorrect'}`, default `'exclude'`. How to treat
+  samples where `y_true == baseline`.
+
+**Returns:** float in [0, 1]. 1.0 = perfect directional prediction, 0.5 = random baseline.
+
+**Common mistakes:**
+
+* Passing a single-element array with `baseline=None` — raises `ValueError`. You need at least
+  2 samples in time-series mode.
+* Forgetting that in time-series mode the first sample is dropped (it has no prior value), so a
+  5-element input yields 4 evaluated steps.
+
+---
+
+## directional_bias_score
+
+Calculates the systematic tendency of a model to over-predict or under-predict the target values.
+Returns a score where 1.0 is complete over-prediction, -1.0 is complete under-prediction, and
+0.0 is perfectly balanced.
+
+```python
+from ds_utils.metrics.time_series import directional_bias_score
+import numpy as np
+
+y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+y_pred = np.array([1.1, 2.1, 3.1, 4.1, 5.1])
+bias = directional_bias_score(y_true, y_pred)
+print(f"Directional Bias: {bias:.2f}")
+```
+
+**Parameters:**
+
+* `y_true` — array-like of shape (n_samples,). True target values.
+* `y_pred` — array-like of shape (n_samples,). Predicted target values.
+* `sample_weight` — array-like, optional. Sample weights.
+* `handle_equal` — `{'exclude', 'neutral'}`, default `'exclude'`. How to treat samples where `y_pred == y_true`.
+
+**Returns:** float in [-1, 1].
+
+**Common mistakes:**
+
+* Using `handle_equal='exclude'` (default) on a dataset where all predictions are exactly correct — raises `ValueError`. Use `'neutral'` if you expect and want to include perfect predictions.
+
+---
+
 ## Typical Workflow
 
 ```python
@@ -402,4 +475,10 @@ report_df = generate_error_analysis_report(
     bins=3
 )
 print(report_df)
+
+# 8. Directional Metrics (for time-series/forecasting)
+from ds_utils.metrics.time_series import directional_accuracy_score, directional_bias_score
+da = directional_accuracy_score(y_test, y_pred)
+bias = directional_bias_score(y_test, y_pred)
+print(f"DA: {da:.2%}, Bias: {bias:.2f}")
 ```

--- a/tests/test_metrics/test_time_series.py
+++ b/tests/test_metrics/test_time_series.py
@@ -32,8 +32,9 @@ def test_directional_accuracy_all_wrong():
 
 def test_directional_accuracy_time_series_default():
     """Test directional_accuracy_score in default time-series mode."""
-    # true changes from prev: +2, -4, +3, -2
-    # pred changes from prev: +2.5, -6, +5, -4  -> all correct
+    # time series mode: baseline = y_true[:-1] = [100, 102, 98, 101]
+    # true changes from baseline: +2, -4, +3, -2  (signs: +, -, +, -)
+    # pred changes from baseline: +3, -5, +4, -3  (signs: +, -, +, -)  -> all directions match
     y_true = np.array([100, 102, 98, 101, 99])
     y_pred = np.array([100.5, 103, 97, 102, 98])
     assert directional_accuracy_score(y_true, y_pred) == pytest.approx(1.0)

--- a/tests/test_metrics/test_time_series.py
+++ b/tests/test_metrics/test_time_series.py
@@ -1,0 +1,270 @@
+"""Tests for the time_series metrics."""
+
+import numpy as np
+import pytest
+from ds_utils.metrics.time_series import directional_accuracy_score, directional_bias_score
+
+
+def test_directional_accuracy_perfect_prediction():
+    """Test directional_accuracy_score with perfect predictions."""
+    y_true = np.array([100, 102, 98, 101, 99, 103])
+    y_pred = np.array([100.5, 102.5, 97.5, 101.5, 98.5, 103.5])
+    assert directional_accuracy_score(y_true, y_pred) == pytest.approx(1.0)
+
+
+def test_directional_accuracy_random_prediction():
+    """Test directional_accuracy_score with random predictions against baseline."""
+    # Corrected data that genuinely yields 0.5:
+    # true dirs: [+, -, +, -]; pred dirs: [+, -, -, +] -> correct at 0, 1; wrong at 2, 3 -> 2/4 = 0.5
+    y_true = np.array([102.0, 98.0, 101.0, 99.0])
+    baseline = np.array([100.0, 100.0, 100.0, 100.0])
+    y_pred = np.array([101.0, 99.0, 99.0, 101.0])
+    assert directional_accuracy_score(y_true, y_pred, baseline=baseline) == pytest.approx(0.5)
+
+
+def test_directional_accuracy_all_wrong():
+    """Test directional_accuracy_score with all wrong predictions."""
+    y_true = np.array([100, 102, 98, 101, 99])
+    baseline = np.array([100, 100, 100, 100, 100])
+    y_pred = np.array([99, 97, 101, 98, 102])
+    assert directional_accuracy_score(y_true, y_pred, baseline=baseline) == pytest.approx(0.0)
+
+
+def test_directional_accuracy_time_series_default():
+    """Test directional_accuracy_score in default time-series mode."""
+    # true changes from prev: +2, -4, +3, -2
+    # pred changes from prev: +2.5, -6, +5, -4  -> all correct
+    y_true = np.array([100, 102, 98, 101, 99])
+    y_pred = np.array([100.5, 103, 97, 102, 98])
+    assert directional_accuracy_score(y_true, y_pred) == pytest.approx(1.0)
+
+
+def test_directional_accuracy_insufficient_samples():
+    """Test directional_accuracy_score raises error for insufficient samples."""
+    with pytest.raises(ValueError, match="at least 2 samples"):
+        directional_accuracy_score(np.array([100]), np.array([101]))
+
+
+def test_directional_accuracy_shape_mismatch():
+    """Test directional_accuracy_score raises error for shape mismatch."""
+    with pytest.raises(ValueError, match="Shape mismatch"):
+        directional_accuracy_score(np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0]))
+
+
+def test_directional_accuracy_baseline_shape_mismatch():
+    """Test directional_accuracy_score raises error for baseline shape mismatch."""
+    with pytest.raises(ValueError, match="Shape mismatch"):
+        directional_accuracy_score(
+            np.array([1.0, 2.0, 3.0]),
+            np.array([1.0, 2.0, 3.0]),
+            baseline=np.array([1.0, 1.0]),
+        )
+
+
+def test_directional_accuracy_invalid_handle_equal():
+    """Test directional_accuracy_score raises error for invalid handle_equal."""
+    with pytest.raises(ValueError, match="handle_equal must be"):
+        directional_accuracy_score(
+            np.array([1.0, 2.0, 3.0]),
+            np.array([1.0, 2.0, 3.0]),
+            baseline=np.array([1.0, 1.0, 1.0]),
+            handle_equal="invalid",
+        )
+
+
+@pytest.mark.parametrize(
+    ("handle_equal", "expected"),
+    [
+        ("exclude", 1.0),
+        ("correct", 0.6),
+        ("incorrect", 0.4),
+    ],
+)
+def test_directional_accuracy_handle_equal(handle_equal, expected):
+    """Test directional_accuracy_score handle_equal logic."""
+    y_true = np.array([100.0, 100.0, 102.0, 100.0, 98.0])
+    baseline = np.array([100.0, 100.0, 100.0, 100.0, 100.0])
+    y_pred = np.array([100.0, 101.0, 103.0, 99.0, 97.0])
+    assert directional_accuracy_score(
+        y_true, y_pred, baseline=baseline, handle_equal=handle_equal
+    ) == pytest.approx(expected)
+
+
+def test_directional_accuracy_with_weights_all_correct():
+    """Test directional_accuracy_score with sample weights and all correct predictions."""
+    y_true = np.array([100, 102, 98, 101])
+    baseline = np.array([100, 100, 100, 100])
+    y_pred = np.array([101, 103, 97, 102])
+    weights = np.array([2.0, 1.0, 1.0, 1.0])
+    assert directional_accuracy_score(
+        y_true, y_pred, baseline=baseline, sample_weight=weights
+    ) == pytest.approx(1.0)
+
+
+def test_directional_accuracy_with_weights_partial():
+    """Test directional_accuracy_score with sample weights and partial correct predictions."""
+    # true directions: +2, -2; pred: +1 (correct), +1 (wrong)
+    # weights 3.0, 1.0 -> correct weight = 3.0, total = 4.0 -> 0.75
+    y_true = np.array([102.0, 98.0])
+    baseline = np.array([100.0, 100.0])
+    y_pred = np.array([101.0, 101.0])
+    weights = np.array([3.0, 1.0])
+    assert directional_accuracy_score(
+        y_true, y_pred, baseline=baseline, sample_weight=weights
+    ) == pytest.approx(0.75)
+
+
+def test_directional_accuracy_with_weights_time_series():
+    """Test directional_accuracy_score with sample weights in time-series mode."""
+    y_true = np.array([100, 102, 98])
+    y_pred = np.array([100, 103, 97])
+    weights = np.array([10, 2, 3])
+    # time series mode:
+    # baseline = [100, 102]
+    # y_true_sliced = [102, 98]
+    # y_pred_sliced = [103, 97]
+    # weights_sliced = [2, 3]
+    # true dirs: [+1, -1]
+    # pred dirs: [+1, -1] -> all correct
+    assert directional_accuracy_score(y_true, y_pred, sample_weight=weights) == pytest.approx(1.0)
+
+
+def test_directional_accuracy_weight_mismatch():
+    """Test directional_accuracy_score raises error for weight length mismatch."""
+    with pytest.raises(ValueError, match="Sample weight length"):
+        directional_accuracy_score(
+            np.array([1, 2]), np.array([1, 2]), baseline=np.array([0, 0]), sample_weight=np.array([1])
+        )
+    with pytest.raises(ValueError, match="Sample weight length"):
+        directional_accuracy_score(np.array([1, 2]), np.array([1, 2]), sample_weight=np.array([1]))
+
+
+def test_directional_accuracy_no_valid_samples_after_exclude():
+    """Test directional_accuracy_score raises error when no samples remain after exclude."""
+    # All y_true == baseline -> exclude removes everything
+    y_true = np.array([100.0, 100.0, 100.0])
+    baseline = np.array([100.0, 100.0, 100.0])
+    y_pred = np.array([101.0, 99.0, 100.0])
+    with pytest.raises(ValueError, match="No valid samples remain"):
+        directional_accuracy_score(y_true, y_pred, baseline=baseline, handle_equal="exclude")
+
+
+def test_directional_bias_no_bias():
+    """Test directional_bias_score with balanced predictions."""
+    # 2 over, 2 under, 1 equal -> exclude the equal -> (2-2)/4 = 0.0
+    y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    y_pred = np.array([1.1, 1.9, 3.1, 3.9, 5.0])
+    assert directional_bias_score(y_true, y_pred, handle_equal="exclude") == pytest.approx(0.0)
+
+
+def test_directional_bias_complete_over_prediction():
+    """Test directional_bias_score with complete over-prediction."""
+    y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    y_pred = np.array([1.1, 2.1, 3.1, 4.1, 5.1])
+    assert directional_bias_score(y_true, y_pred) == pytest.approx(1.0)
+
+
+def test_directional_bias_complete_under_prediction():
+    """Test directional_bias_score with complete under-prediction."""
+    y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    y_pred = np.array([0.9, 1.9, 2.9, 3.9, 4.9])
+    assert directional_bias_score(y_true, y_pred) == pytest.approx(-1.0)
+
+
+def test_directional_bias_mostly_over():
+    """Test directional_bias_score with mostly over-predictions."""
+    # 3 over, 2 under -> (3-2)/5 = 0.2
+    y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    y_pred = np.array([1.1, 2.1, 3.1, 3.9, 4.9])
+    assert directional_bias_score(y_true, y_pred) == pytest.approx(0.2)
+
+
+def test_directional_bias_shape_mismatch():
+    """Test directional_bias_score raises error for shape mismatch."""
+    with pytest.raises(ValueError, match="Shape mismatch"):
+        directional_bias_score(np.array([1.0, 2.0, 3.0]), np.array([1.0, 2.0]))
+
+
+def test_directional_bias_invalid_handle_equal():
+    """Test directional_bias_score raises error for invalid handle_equal."""
+    with pytest.raises(ValueError, match="handle_equal must be"):
+        directional_bias_score(
+            np.array([1.0, 2.0, 3.0]),
+            np.array([1.0, 2.0, 3.0]),
+            handle_equal="invalid",
+        )
+
+
+@pytest.mark.parametrize(
+    ("handle_equal", "expected"),
+    [
+        ("exclude", 1.0),
+        ("neutral", 0.6),
+    ],
+)
+def test_directional_bias_handle_equal(handle_equal, expected):
+    """Test directional_bias_score handle_equal logic."""
+    # 3 over, 0 under, 2 equal -> exclude -> (3-0)/3 = 1.0
+    # 3 over, 0 under, 2 equal -> neutral -> (3-0)/5 = 0.6
+    y_true = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+    y_pred = np.array([1.1, 2.0, 3.1, 4.0, 5.1])
+    assert directional_bias_score(y_true, y_pred, handle_equal=handle_equal) == pytest.approx(expected)
+
+
+def test_directional_bias_with_weights_balanced():
+    """Test directional_bias_score with sample weights and balanced predictions."""
+    # 2 over, 2 under, equal weights -> 0.0
+    y_true = np.array([1.0, 2.0, 3.0, 4.0])
+    y_pred = np.array([1.1, 2.1, 2.9, 3.9])
+    assert directional_bias_score(y_true, y_pred) == pytest.approx(0.0)
+
+
+def test_directional_bias_with_weights_skewed():
+    """Test directional_bias_score with sample weights and skewed predictions."""
+    # 2 over (weights 2, 2), 2 under (weights 1, 1)
+    # prop_over = 4/6, prop_under = 2/6 -> bias = 2/6 ≈ 0.3333
+    y_true = np.array([1.0, 2.0, 3.0, 4.0])
+    y_pred = np.array([1.1, 2.1, 2.9, 3.9])
+    weights = np.array([2.0, 2.0, 1.0, 1.0])
+    assert directional_bias_score(y_true, y_pred, sample_weight=weights) == pytest.approx(
+        1 / 3, rel=1e-4
+    )
+
+
+def test_directional_bias_weight_mismatch():
+    """Test directional_bias_score raises error for weight length mismatch."""
+    with pytest.raises(ValueError, match="Sample weight length"):
+        directional_bias_score(np.array([1, 2]), np.array([1, 2]), sample_weight=np.array([1]))
+
+
+def test_directional_bias_all_equal_raises():
+    """Test directional_bias_score raises error when no samples remain after exclude."""
+    y_true = np.array([1.0, 2.0, 3.0])
+    y_pred = np.array([1.0, 2.0, 3.0])
+    with pytest.raises(ValueError, match="No valid samples remain"):
+        directional_bias_score(y_true, y_pred, handle_equal="exclude")
+
+
+def test_directional_metrics_on_simulated_time_series():
+    """Integration test: model performance on simulated time-series."""
+    rng = np.random.default_rng(42)
+    n = 100
+    true_prices = 100 + np.cumsum(rng.standard_normal(n) * 2)
+    good_pred = true_prices + rng.standard_normal(n) * 0.5   # tight errors
+    bad_pred = 100 + np.cumsum(rng.standard_normal(n) * 2)   # independent walk
+
+    da_good = directional_accuracy_score(true_prices, good_pred)
+    da_bad = directional_accuracy_score(true_prices, bad_pred)
+    assert da_good > da_bad
+    assert da_good > 0.5
+
+    bias_good = directional_bias_score(true_prices, good_pred)
+    assert abs(bias_good) < 0.3
+
+
+def test_consistent_over_predictor():
+    """Integration test: uniformly shifted predictor."""
+    y_true = np.array([100.0, 102.0, 98.0, 101.0, 99.0, 103.0])
+    y_pred = y_true + 1.0
+    assert directional_bias_score(y_true, y_pred) == pytest.approx(1.0)
+    assert directional_accuracy_score(y_true, y_pred) == pytest.approx(1.0)

--- a/tests/test_metrics/test_time_series.py
+++ b/tests/test_metrics/test_time_series.py
@@ -125,12 +125,16 @@ def test_directional_accuracy_with_weights_time_series():
     assert directional_accuracy_score(y_true, y_pred, sample_weight=weights) == pytest.approx(1.0)
 
 
-def test_directional_accuracy_weight_mismatch():
-    """Test directional_accuracy_score raises error for weight length mismatch."""
+def test_directional_accuracy_weight_mismatch_with_baseline():
+    """Test directional_accuracy_score raises error for weight length mismatch with explicit baseline."""
     with pytest.raises(ValueError, match="Sample weight length"):
         directional_accuracy_score(
             np.array([1, 2]), np.array([1, 2]), baseline=np.array([0, 0]), sample_weight=np.array([1])
         )
+
+
+def test_directional_accuracy_weight_mismatch_time_series():
+    """Test directional_accuracy_score raises error for weight length mismatch in time-series mode."""
     with pytest.raises(ValueError, match="Sample weight length"):
         directional_accuracy_score(np.array([1, 2]), np.array([1, 2]), sample_weight=np.array([1]))
 
@@ -223,6 +227,22 @@ def test_directional_bias_with_weights_skewed():
     y_pred = np.array([1.1, 2.1, 2.9, 3.9])
     weights = np.array([2.0, 2.0, 1.0, 1.0])
     assert directional_bias_score(y_true, y_pred, sample_weight=weights) == pytest.approx(1 / 3, rel=1e-4)
+
+
+def test_directional_bias_with_weights_and_exclusion_filtering():
+    """Test directional_bias_score with weights when exclude removes zero-error samples."""
+    # errors: [+0.1, 0.0, -0.1, +0.2]
+    # handle_equal='exclude' removes index 1 (error == 0)
+    # remaining: [+0.1, -0.1, +0.2] with weights [1.0, 2.0, 3.0] (original [1.0, 5.0, 2.0, 3.0])
+    # normalized weights: [1/6, 2/6, 3/6]
+    # prop_over = (1 + 3) / 6 = 4/6
+    # prop_under = 2/6
+    # bias = (4-2)/6 = 2/6 ≈ 0.3333
+    y_true = np.array([1.0, 2.0, 3.0, 4.0])
+    y_pred = np.array([1.1, 2.0, 2.9, 4.2])
+    weights = np.array([1.0, 5.0, 2.0, 3.0])
+    result = directional_bias_score(y_true, y_pred, sample_weight=weights, handle_equal="exclude")
+    assert result == pytest.approx(1 / 3, rel=1e-4)
 
 
 def test_directional_bias_weight_mismatch():

--- a/tests/test_metrics/test_time_series.py
+++ b/tests/test_metrics/test_time_series.py
@@ -85,9 +85,9 @@ def test_directional_accuracy_handle_equal(handle_equal, expected):
     y_true = np.array([100.0, 100.0, 102.0, 100.0, 98.0])
     baseline = np.array([100.0, 100.0, 100.0, 100.0, 100.0])
     y_pred = np.array([100.0, 101.0, 103.0, 99.0, 97.0])
-    assert directional_accuracy_score(
-        y_true, y_pred, baseline=baseline, handle_equal=handle_equal
-    ) == pytest.approx(expected)
+    assert directional_accuracy_score(y_true, y_pred, baseline=baseline, handle_equal=handle_equal) == pytest.approx(
+        expected
+    )
 
 
 def test_directional_accuracy_with_weights_all_correct():
@@ -96,9 +96,7 @@ def test_directional_accuracy_with_weights_all_correct():
     baseline = np.array([100, 100, 100, 100])
     y_pred = np.array([101, 103, 97, 102])
     weights = np.array([2.0, 1.0, 1.0, 1.0])
-    assert directional_accuracy_score(
-        y_true, y_pred, baseline=baseline, sample_weight=weights
-    ) == pytest.approx(1.0)
+    assert directional_accuracy_score(y_true, y_pred, baseline=baseline, sample_weight=weights) == pytest.approx(1.0)
 
 
 def test_directional_accuracy_with_weights_partial():
@@ -109,9 +107,7 @@ def test_directional_accuracy_with_weights_partial():
     baseline = np.array([100.0, 100.0])
     y_pred = np.array([101.0, 101.0])
     weights = np.array([3.0, 1.0])
-    assert directional_accuracy_score(
-        y_true, y_pred, baseline=baseline, sample_weight=weights
-    ) == pytest.approx(0.75)
+    assert directional_accuracy_score(y_true, y_pred, baseline=baseline, sample_weight=weights) == pytest.approx(0.75)
 
 
 def test_directional_accuracy_with_weights_time_series():
@@ -226,9 +222,7 @@ def test_directional_bias_with_weights_skewed():
     y_true = np.array([1.0, 2.0, 3.0, 4.0])
     y_pred = np.array([1.1, 2.1, 2.9, 3.9])
     weights = np.array([2.0, 2.0, 1.0, 1.0])
-    assert directional_bias_score(y_true, y_pred, sample_weight=weights) == pytest.approx(
-        1 / 3, rel=1e-4
-    )
+    assert directional_bias_score(y_true, y_pred, sample_weight=weights) == pytest.approx(1 / 3, rel=1e-4)
 
 
 def test_directional_bias_weight_mismatch():
@@ -250,8 +244,8 @@ def test_directional_metrics_on_simulated_time_series():
     rng = np.random.default_rng(42)
     n = 100
     true_prices = 100 + np.cumsum(rng.standard_normal(n) * 2)
-    good_pred = true_prices + rng.standard_normal(n) * 0.5   # tight errors
-    bad_pred = 100 + np.cumsum(rng.standard_normal(n) * 2)   # independent walk
+    good_pred = true_prices + rng.standard_normal(n) * 0.5  # tight errors
+    bad_pred = 100 + np.cumsum(rng.standard_normal(n) * 2)  # independent walk
 
     da_good = directional_accuracy_score(true_prices, good_pred)
     da_bad = directional_accuracy_score(true_prices, bad_pred)


### PR DESCRIPTION
This PR adds two new scalar metric functions for time-series and forecasting use cases: directional_accuracy_score and directional_bias_score. These metrics help evaluate trend direction and systematic prediction bias, following the patterns of the DataScienceUtils library. Full documentation and 100% test coverage are included.

---
*PR created automatically by Jules for task [7428174708245335973](https://jules.google.com/task/7428174708245335973) started by @idanmoradarthas*