### PR TITLE
Update documentation for transformers package refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,14 +502,14 @@ The output for ``terms`` will be the following table:
 
 ## Transformers
 
-The ``transformers`` module provides scikit-learn compatible wrappers for preprocessing steps that need ``get_feature_names_out`` (feature names in pipelines) and consistent ``float64`` output.
+The ``transformers`` package provides scikit-learn compatible wrappers for preprocessing steps that need ``get_feature_names_out`` (feature names in pipelines) and consistent ``float64`` output.
 
 ### MultiLabelBinarizerTransformer
 
 Wraps ``sklearn.preprocessing.MultiLabelBinarizer`` so multi-label columns work with ``Pipeline``, ``ColumnTransformer``, and ``set_output(transform="pandas")``. Pass **one iterable of labels per sample** (see the `MultiLabelBinarizer <https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.MultiLabelBinarizer.html>`_ documentation—a flat list of strings is not valid input).
 
 ```python
-from ds_utils.transformers import MultiLabelBinarizerTransformer
+from ds_utils.transformers.multi_label_binarizer import MultiLabelBinarizerTransformer
 from sklearn.pipeline import Pipeline
 
 X = [["sci-fi", "action"], ["romance"], ["action", "comedy"]]

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,7 @@ visualizations for data science projects.
    metrics/index
    preprocess/index
    strings
-   transformers
+   transformers/index
    unsupervised
    xai
    contributing

--- a/docs/source/transformers.rst
+++ b/docs/source/transformers.rst
@@ -2,7 +2,7 @@
 Transformers
 ############
 
-The ``ds_utils.transformers`` module provides scikit-learn compatible transformers that wrap
+The ``ds_utils.transformers`` package provides scikit-learn compatible transformers that wrap
 or extend preprocessing estimators with ``get_feature_names_out`` (feature names API, SLEP007)
 and consistent output dtypes for pipelines and :class:`~sklearn.compose.ColumnTransformer`.
 
@@ -10,7 +10,7 @@ and consistent output dtypes for pipelines and :class:`~sklearn.compose.ColumnTr
 MultiLabelBinarizerTransformer
 ********************************
 
-.. autoclass:: ds_utils.transformers.MultiLabelBinarizerTransformer
+.. autoclass:: ds_utils.transformers.multi_label_binarizer.MultiLabelBinarizerTransformer
    :members:
 
 .. highlight:: python
@@ -19,7 +19,7 @@ Example
 =======
 ::
 
-    from ds_utils.transformers import MultiLabelBinarizerTransformer
+    from ds_utils.transformers.multi_label_binarizer import MultiLabelBinarizerTransformer
     from sklearn.pipeline import Pipeline
 
     X = [["sci-fi", "action"], ["romance"], ["action", "comedy"]]

--- a/docs/source/transformers/index.rst
+++ b/docs/source/transformers/index.rst
@@ -1,0 +1,12 @@
+############
+Transformers
+############
+
+The ``ds_utils.transformers`` package provides scikit-learn compatible transformers that wrap
+or extend preprocessing estimators with ``get_feature_names_out`` (feature names API, SLEP007)
+and consistent output dtypes for pipelines and :class:`~sklearn.compose.ColumnTransformer`.
+
+.. toctree::
+   :maxdepth: 2
+
+   multi_label_binarizer

--- a/docs/source/transformers/multi_label_binarizer.rst
+++ b/docs/source/transformers/multi_label_binarizer.rst
@@ -21,10 +21,9 @@ Direct usage::
     X_t = mlb.fit_transform(X)
     names = mlb.get_feature_names_out()
 
-``X_t`` is a numpy array of shape ``(n_samples, n_classes)``, dtype ``float64``.
-``names`` contains the feature names, e.g. ``['label_action', 'label_comedy', 'label_romance', 'label_sci-fi']``.
-
-Their output will be:
+``X_t`` is a numpy array of shape ``(n_samples, n_classes)``, dtype ``float64``, with columns
+corresponding to ``names`` (e.g. ``['label_action', 'label_comedy', 'label_romance', 'label_sci-fi']``).
+The output will be:
 
 +------------+------------+-------------+------------+
 |label_action|label_comedy|label_romance|label_sci-fi|

--- a/docs/source/transformers/multi_label_binarizer.rst
+++ b/docs/source/transformers/multi_label_binarizer.rst
@@ -1,36 +1,23 @@
-############
-Transformers
-############
-
-The ``ds_utils.transformers`` package provides scikit-learn compatible transformers that wrap
-or extend preprocessing estimators with ``get_feature_names_out`` (feature names API, SLEP007)
-and consistent output dtypes for pipelines and :class:`~sklearn.compose.ColumnTransformer`.
-
-********************************
+******************************
 MultiLabelBinarizerTransformer
-********************************
+******************************
 
 .. autoclass:: ds_utils.transformers.multi_label_binarizer.MultiLabelBinarizerTransformer
    :members:
 
 .. highlight:: python
 
-Example
-=======
-::
+Code Examples
+=============
+
+Direct usage::
 
     from ds_utils.transformers.multi_label_binarizer import MultiLabelBinarizerTransformer
-    from sklearn.pipeline import Pipeline
 
     X = [["sci-fi", "action"], ["romance"], ["action", "comedy"]]
     mlb = MultiLabelBinarizerTransformer()
     X_t = mlb.fit_transform(X)
-
     names = mlb.get_feature_names_out()
-
-    pipe = Pipeline([("mlb", MultiLabelBinarizerTransformer())])
-    pipe.set_output(transform="pandas")
-    df = pipe.fit_transform(X)
 
 Both ``X_t`` (as a numpy array) and ``df`` (as a pandas DataFrame) contain the same binarized data.
 Their output will be:
@@ -44,3 +31,25 @@ Their output will be:
 +------------+------------+-------------+------------+
 |1.0         |1.0         |0.0          |0.0         |
 +------------+------------+-------------+------------+
+
+Pipeline usage with pandas output::
+
+    from ds_utils.transformers.multi_label_binarizer import MultiLabelBinarizerTransformer
+    from sklearn.pipeline import Pipeline
+
+    pipe = Pipeline([("mlb", MultiLabelBinarizerTransformer())])
+    pipe.set_output(transform="pandas")
+    df = pipe.fit_transform(X)
+
+ColumnTransformer usage::
+
+    from ds_utils.transformers.multi_label_binarizer import MultiLabelBinarizerTransformer
+    from sklearn.compose import ColumnTransformer
+    import pandas as pd
+
+    df = pd.DataFrame({"tags": [["x", "y"], ["z"]], "num": [1.0, 2.0]})
+    pre = ColumnTransformer(
+        [("mlb", MultiLabelBinarizerTransformer(), ["tags"])],
+        remainder="passthrough",
+    )
+    X_out = pre.fit_transform(df)

--- a/docs/source/transformers/multi_label_binarizer.rst
+++ b/docs/source/transformers/multi_label_binarizer.rst
@@ -10,6 +10,8 @@ MultiLabelBinarizerTransformer
 Code Examples
 =============
 
+The following examples show the three main ways to use ``MultiLabelBinarizerTransformer``.
+
 Direct usage::
 
     from ds_utils.transformers.multi_label_binarizer import MultiLabelBinarizerTransformer
@@ -19,7 +21,9 @@ Direct usage::
     X_t = mlb.fit_transform(X)
     names = mlb.get_feature_names_out()
 
-Both ``X_t`` (as a numpy array) and ``df`` (as a pandas DataFrame) contain the same binarized data.
+``X_t`` is a numpy array of shape ``(n_samples, n_classes)``, dtype ``float64``.
+``names`` contains the feature names, e.g. ``['label_action', 'label_comedy', 'label_romance', 'label_sci-fi']``.
+
 Their output will be:
 
 +------------+------------+-------------+------------+

--- a/skills/transformers/SKILL.md
+++ b/skills/transformers/SKILL.md
@@ -24,7 +24,7 @@ conda install -c idanmorad data-science-utils
 ## Import
 
 ```python
-from ds_utils.transformers import MultiLabelBinarizerTransformer
+from ds_utils.transformers.multi_label_binarizer import MultiLabelBinarizerTransformer
 ```
 
 ---
@@ -36,7 +36,7 @@ Wraps `sklearn.preprocessing.MultiLabelBinarizer` so pipelines get `get_feature_
 **1. Direct Object Usage:**
 
 ```python
-from ds_utils.transformers import MultiLabelBinarizerTransformer
+from ds_utils.transformers.multi_label_binarizer import MultiLabelBinarizerTransformer
 
 X = [["sci-fi", "action"], ["romance"], ["action", "comedy"]]
 mlb = MultiLabelBinarizerTransformer()
@@ -54,7 +54,7 @@ feature_names = mlb.get_feature_names_out()
 **2. Pipeline Usage with Pandas Output:**
 
 ```python
-from ds_utils.transformers import MultiLabelBinarizerTransformer
+from ds_utils.transformers.multi_label_binarizer import MultiLabelBinarizerTransformer
 from sklearn.pipeline import Pipeline
 
 X = [["sci-fi", "action"], ["romance"], ["action", "comedy"]]
@@ -88,7 +88,7 @@ df = pipe.fit_transform(X)
 **Typical workflow**
 
 ```python
-from ds_utils.transformers import MultiLabelBinarizerTransformer
+from ds_utils.transformers.multi_label_binarizer import MultiLabelBinarizerTransformer
 from sklearn.compose import ColumnTransformer
 
 # Single column "tags" in a DataFrame


### PR DESCRIPTION
Updated README, Sphinx docs, and SKILL file to reflect the restructuring of `ds_utils.transformers` from a module into a package. All import paths for `MultiLabelBinarizerTransformer` have been updated to use the explicit submodule path `ds_utils.transformers.multi_label_binarizer`.

---
*PR created automatically by Jules for task [9712783246661387045](https://jules.google.com/task/9712783246661387045) started by @idanmoradarthas*